### PR TITLE
ci: fix Release Please deprecation warnings

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,8 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Release Please
-        uses: google-github-actions/release-please-action@v4
+        uses: googleapis/release-please-action@v4
         with:
           release-type: node
-          package-name: scan-mcp
-          default-branch: main
+          target-branch: main


### PR DESCRIPTION
Switch to googleapis/release-please-action@v4 and remove unsupported inputs.