### PR TITLE
feat: add runtime preflight checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Add a server entry to your MCP client configuration:
 ## Install
 
 - Run with npx: `npx scan-mcp`
+  - The CLI runs a quick preflight check for Node 22+ and required scanner/image tools and prints installation hints if anything is missing.
 - CLI help: `scan-mcp --help`
 - Install npm: `npm i -g scan-mcp` then `scan-mcp`
 - From source (development):

--- a/bin/scan-mcp
+++ b/bin/scan-mcp
@@ -50,10 +50,42 @@ if (wantsVersion) {
   process.exit(0);
 }
 
-// Load and run the built entrypoint from dist
-import('../dist/mcp.js')
-  .then((mod) => (typeof mod.main === 'function' ? mod.main() : undefined))
-  .catch((err) => {
-    console.error(err);
+async function bootstrap() {
+  try {
+    const preflight = await import('../dist/preflight.js');
+    if (typeof preflight.ensureEnvironmentReady === 'function') {
+      try {
+        await preflight.ensureEnvironmentReady();
+      } catch (error) {
+        if (preflight.PreflightError && error instanceof preflight.PreflightError) {
+          console.error(error.message);
+          process.exit(1);
+          return;
+        }
+        throw error;
+      }
+    }
+  } catch (error) {
+    console.error(error);
     process.exit(1);
-  });
+    return;
+  }
+
+  try {
+    const mod = await import('../dist/mcp.js');
+    if (typeof mod.main !== 'function') {
+      console.error('scan-mcp entrypoint missing main() export');
+      process.exit(1);
+      return;
+    }
+    await mod.main();
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+}
+
+bootstrap().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/preflight.ts
+++ b/src/preflight.ts
@@ -23,6 +23,10 @@ const REQUIRED_TOOLS: readonly RequiredTool[] = [
 
 export type MissingDependency = RequiredTool & { command: string };
 
+export interface DetectMissingDependenciesOptions {
+  commandAvailable?: (command: string) => boolean;
+}
+
 export type PreflightErrorDetails =
   | { type: "node-version"; requiredMajor: number; currentVersion: string }
   | { type: "missing-dependencies"; missing: MissingDependency[] };
@@ -84,11 +88,15 @@ export function ensureEnvironmentReady(options: EnsureEnvironmentOptions = {}): 
   }
 }
 
-export function detectMissingDependencies(config: AppConfig): MissingDependency[] {
+export function detectMissingDependencies(
+  config: AppConfig,
+  options: DetectMissingDependenciesOptions = {}
+): MissingDependency[] {
+  const isAvailable = options.commandAvailable ?? isCommandAvailable;
   const missing: MissingDependency[] = [];
   for (const tool of REQUIRED_TOOLS) {
     const configured = (config[tool.envVar] ?? "").trim();
-    if (!configured || !isCommandAvailable(configured)) {
+    if (!configured || !isAvailable(configured)) {
       missing.push({ ...tool, command: configured || tool.defaultCommand });
     }
   }

--- a/src/preflight.ts
+++ b/src/preflight.ts
@@ -1,0 +1,156 @@
+import os from "os";
+import path from "path";
+import { spawnSync } from "child_process";
+import { accessSync, constants, statSync } from "fs";
+import { loadConfig } from "./config.js";
+import type { AppConfig } from "./config.js";
+
+const MIN_NODE_MAJOR_VERSION = 22;
+
+type CommandEnvVar = "SCANIMAGE_BIN" | "TIFFCP_BIN" | "IM_CONVERT_BIN";
+
+type RequiredTool = {
+  envVar: CommandEnvVar;
+  defaultCommand: string;
+  description: string;
+};
+
+const REQUIRED_TOOLS: readonly RequiredTool[] = [
+  { envVar: "SCANIMAGE_BIN", defaultCommand: "scanimage", description: "SANE CLI (scanimage)" },
+  { envVar: "TIFFCP_BIN", defaultCommand: "tiffcp", description: "TIFF page assembler (tiffcp)" },
+  { envVar: "IM_CONVERT_BIN", defaultCommand: "convert", description: "ImageMagick convert" },
+] as const;
+
+export type MissingDependency = RequiredTool & { command: string };
+
+export type PreflightErrorDetails =
+  | { type: "node-version"; requiredMajor: number; currentVersion: string }
+  | { type: "missing-dependencies"; missing: MissingDependency[] };
+
+export class PreflightError extends Error {
+  public readonly code = "SCAN_MCP_PREFLIGHT_FAILED" as const;
+  public readonly details: PreflightErrorDetails;
+
+  constructor(message: string, details: PreflightErrorDetails) {
+    super(message);
+    this.name = "PreflightError";
+    this.details = details;
+  }
+}
+
+export interface EnsureEnvironmentOptions {
+  nodeVersion?: string;
+  config?: AppConfig;
+  skipCommandCheck?: boolean;
+}
+
+export function ensureEnvironmentReady(options: EnsureEnvironmentOptions = {}): void {
+  const nodeVersion = options.nodeVersion ?? process.version;
+  const majorVersion = parseNodeMajor(nodeVersion);
+  if (!majorVersion || majorVersion < MIN_NODE_MAJOR_VERSION) {
+    const message = [
+      `scan-mcp requires Node.js ${MIN_NODE_MAJOR_VERSION} or newer (current: ${formatNodeVersion(nodeVersion)}).`,
+      "Update your runtime before running `npx scan-mcp`.",
+      "If you use nvm:",
+      "  nvm install 22",
+      "  nvm use 22",
+    ].join("\n");
+    throw new PreflightError(message, {
+      type: "node-version",
+      requiredMajor: MIN_NODE_MAJOR_VERSION,
+      currentVersion: formatNodeVersion(nodeVersion),
+    });
+  }
+
+  if (options.skipCommandCheck) return;
+
+  const config = options.config ?? loadConfig();
+  const missing = detectMissingDependencies(config);
+  if (missing.length > 0) {
+    const message = [
+      "scan-mcp could not find the system tools it needs to talk to your scanner:",
+      ...missing.map((dep) =>
+        `  • ${dep.description} [${dep.envVar}=${dep.command || dep.defaultCommand}]`
+      ),
+      "",
+      "Install SANE utilities and TIFF tools before continuing:",
+      "  Ubuntu/Debian: sudo apt install sane-utils libtiff-tools imagemagick",
+      "  Arch Linux:    sudo pacman -S sane libtiff imagemagick",
+      "  Fedora:        sudo dnf install sane-backends-utils libtiff-tools ImageMagick",
+      "",
+      "If the tools live elsewhere, set SCANIMAGE_BIN, TIFFCP_BIN, or IM_CONVERT_BIN to point at them.",
+    ].join("\n");
+    throw new PreflightError(message, { type: "missing-dependencies", missing });
+  }
+}
+
+export function detectMissingDependencies(config: AppConfig): MissingDependency[] {
+  const missing: MissingDependency[] = [];
+  for (const tool of REQUIRED_TOOLS) {
+    const configured = (config[tool.envVar] ?? "").trim();
+    if (!configured || !isCommandAvailable(configured)) {
+      missing.push({ ...tool, command: configured || tool.defaultCommand });
+    }
+  }
+  return missing;
+}
+
+function parseNodeMajor(version: string | undefined): number | undefined {
+  if (!version) return undefined;
+  const normalized = version.startsWith("v") ? version.slice(1) : version;
+  const [major] = normalized.split(".");
+  const parsed = Number.parseInt(major ?? "", 10);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+function formatNodeVersion(version: string | undefined): string {
+  if (!version) return "unknown";
+  return version.startsWith("v") ? version : `v${version}`;
+}
+
+function isCommandAvailable(command: string): boolean {
+  const expanded = expandUser(command.trim());
+  if (!expanded) return false;
+  if (hasPathSeparator(expanded)) {
+    const resolved = path.isAbsolute(expanded) ? expanded : path.resolve(expanded);
+    return isExecutable(resolved);
+  }
+
+  if (process.platform === "win32") {
+    const result = spawnSync("where", [expanded], { stdio: "ignore" });
+    return result.status === 0;
+  }
+
+  const quoted = escapeShellArg(expanded);
+  const result = spawnSync("sh", ["-c", `command -v ${quoted} >/dev/null 2>&1`], {
+    stdio: "ignore",
+  });
+  return result.status === 0;
+}
+
+function expandUser(input: string): string {
+  if (!input.startsWith("~")) return input;
+  if (input === "~") return os.homedir();
+  if (input.startsWith("~/")) return path.join(os.homedir(), input.slice(2));
+  return input; // "~user" styles not supported
+}
+
+function hasPathSeparator(command: string): boolean {
+  return command.includes("/") || command.includes("\\");
+}
+
+function isExecutable(filePath: string): boolean {
+  try {
+    const stats = statSync(filePath);
+    if (!stats.isFile() && !stats.isSymbolicLink()) return false;
+    accessSync(filePath, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function escapeShellArg(value: string): string {
+  if (value === "") return "''";
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}

--- a/src/tests/preflight.spec.ts
+++ b/src/tests/preflight.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdtempSync, writeFileSync, chmodSync, rmSync } from "fs";
 import os from "os";
 import path from "path";
@@ -59,7 +59,9 @@ describe("preflight checks", () => {
 
   it("reports all required dependencies when PATH is empty", () => {
     delete process.env.PATH;
-    const missing = detectMissingDependencies(makeConfig());
+    const commandAvailable = vi.fn().mockReturnValue(false);
+    const missing = detectMissingDependencies(makeConfig(), { commandAvailable });
+    expect(commandAvailable).toHaveBeenCalled();
     expect(missing.map((m) => m.envVar).sort()).toEqual([
       "IM_CONVERT_BIN",
       "SCANIMAGE_BIN",

--- a/src/tests/preflight.spec.ts
+++ b/src/tests/preflight.spec.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, writeFileSync, chmodSync, rmSync } from "fs";
+import os from "os";
+import path from "path";
+import type { AppConfig } from "../config.js";
+import { detectMissingDependencies, ensureEnvironmentReady, PreflightError } from "../preflight.js";
+
+describe("preflight checks", () => {
+  let originalPath: string | undefined;
+  let tempDirs: string[];
+
+  beforeEach(() => {
+    originalPath = process.env.PATH;
+    tempDirs = [];
+  });
+
+  afterEach(() => {
+    if (originalPath === undefined) {
+      delete process.env.PATH;
+    } else {
+      process.env.PATH = originalPath;
+    }
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs = [];
+  });
+
+  function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
+    return {
+      LOG_LEVEL: "silent",
+      INBOX_DIR: "/tmp/inbox",
+      SCAN_MOCK: false,
+      SCANIMAGE_BIN: "scanimage",
+      TIFFCP_BIN: "tiffcp",
+      IM_CONVERT_BIN: "convert",
+      SCAN_EXCLUDE_BACKENDS: ["v4l"],
+      SCAN_PREFER_BACKENDS: [],
+      PERSIST_LAST_USED_DEVICE: true,
+      ...overrides,
+    };
+  }
+
+  function setupFakeCommands(names: string[]): void {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "scan-mcp-preflight-"));
+    tempDirs.push(dir);
+    for (const name of names) {
+      const filePath = path.join(dir, name);
+      writeFileSync(filePath, "#!/bin/sh\nexit 0\n");
+      try {
+        chmodSync(filePath, 0o755);
+      } catch {
+        // Ignore chmod failures on platforms that do not support it
+      }
+    }
+    const existingPath = originalPath ? `${dir}${path.delimiter}${originalPath}` : dir;
+    process.env.PATH = existingPath;
+  }
+
+  it("reports all required dependencies when PATH is empty", () => {
+    delete process.env.PATH;
+    const missing = detectMissingDependencies(makeConfig());
+    expect(missing.map((m) => m.envVar).sort()).toEqual([
+      "IM_CONVERT_BIN",
+      "SCANIMAGE_BIN",
+      "TIFFCP_BIN",
+    ]);
+  });
+
+  it("passes when fake commands are available", () => {
+    setupFakeCommands(["scanimage", "tiffcp", "convert"]);
+    const missing = detectMissingDependencies(makeConfig());
+    expect(missing).toEqual([]);
+  });
+
+  it("throws a PreflightError when Node is too old", () => {
+    setupFakeCommands(["scanimage", "tiffcp", "convert"]);
+    expect(() =>
+      ensureEnvironmentReady({
+        nodeVersion: "v21.8.0",
+        config: makeConfig(),
+      })
+    ).toThrow(PreflightError);
+  });
+
+  it("completes successfully when Node and dependencies are satisfied", () => {
+    setupFakeCommands(["scanimage", "tiffcp", "convert"]);
+    expect(() =>
+      ensureEnvironmentReady({
+        nodeVersion: "v22.0.0",
+        config: makeConfig(),
+      })
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- add a runtime preflight module that validates Node 22+ and required scanner tooling before startup
- invoke the preflight from the npx entrypoint and document the new behavior in the README
- cover the checks with unit tests to ensure helpful failures and happy-path success

## Testing
- make verify

------
https://chatgpt.com/codex/tasks/task_e_68c898f93b54832e880337f0bbcf6d94