### PR TITLE
ci: automate MCP registry publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,13 @@ jobs:
           npm run build
           npm run pack:check
           npm test -- --run
+      - name: Ensure server manifest versions match package
+        run: |
+          PACKAGE_VERSION=$(jq -r '.version' package.json)
+          MANIFEST_VERSION=$(jq -r '.version' server.json)
+          MANIFEST_PACKAGE_VERSION=$(jq -r '.packages[0].version' server.json)
+          test "$PACKAGE_VERSION" = "$MANIFEST_VERSION"
+          test "$PACKAGE_VERSION" = "$MANIFEST_PACKAGE_VERSION"
       - name: Publish to npm (Trusted Publishing + provenance)
         env:
           # For Trusted Publishing with provenance, do NOT set NODE_AUTH_TOKEN.
@@ -47,3 +54,11 @@ jobs:
         run: |
           # Best practice: rebuild from source at the tagged commit; do not rely on GitHub release assets.
           npm publish --provenance --access public
+      - name: Install MCP Publisher CLI
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.0.0/mcp-publisher_1.0.0_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
+            | tar xz mcp-publisher
+      - name: Login to MCP Registry (GitHub OIDC)
+        run: ./mcp-publisher login github-oidc
+      - name: Publish server manifest to MCP Registry
+        run: ./mcp-publisher publish

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "scan-mcp",
   "version": "0.2.0",
+  "mcpName": "io.github.jacksenechal/scan-mcp",
   "private": false,
   "type": "module",
   "description": "scan-mcp: MCP server for scanner capture (ADF/duplex/page-size), batching, and multipage assembly",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,18 @@
   "release-type": "node",
   "bump-minor-pre-major": true,
   "include-component-in-tag": false,
+  "extra-files": [
+    {
+      "type": "json",
+      "path": "server.json",
+      "jsonpath": "$.version"
+    },
+    {
+      "type": "json",
+      "path": "server.json",
+      "jsonpath": "$.packages[0].version"
+    }
+  ],
   "changelog-types": [
     {"type": "feat", "section": "Features"},
     {"type": "fix", "section": "Bug Fixes"},

--- a/server.json
+++ b/server.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "name": "io.github.jacksenechal/scan-mcp",
+  "description": "MCP server for scanner discovery and batch capture via SANE",
+  "status": "active",
+  "website_url": "https://github.com/jacksenechal/scan-mcp",
+  "repository": {
+    "url": "https://github.com/jacksenechal/scan-mcp",
+    "source": "github"
+  },
+  "version": "0.2.0",
+  "packages": [
+    {
+      "registry_type": "npm",
+      "registry_base_url": "https://registry.npmjs.org",
+      "identifier": "scan-mcp",
+      "version": "0.2.0",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add server.json manifest and link npm package via mcpName
- extend release workflow to publish to MCP registry after npm release
- teach release-please to bump manifest versions alongside package.json

## Testing
- make verify