### PR TITLE
feat: expose HTTP transport from CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@ Minimal MCP server for scanner capture (ADF/duplex/page-size), batching, and mul
 - Small, typed MCP server exposing tools for device discovery and scan jobs
 - JSON Schema–validated inputs with deterministic, typed outputs
 - Smart device selection (prefers ADF/duplex, avoids camera backends), robust defaults
+- Local-first transports: stdio by default to keep everything on-device, optional HTTP for your own network deployments
 
 Note: This package targets Node 22 and Linux SANE backends (`scanimage`).
 
-## Quick Start (MCP client config)
+## Quick Start (local stdio, default)
 
 Add a server entry to your MCP client configuration:
 
@@ -42,14 +43,30 @@ Add a server entry to your MCP client configuration:
 }
 ```
 
+- This invocation runs over stdio for a privacy-first, single-machine setup.
 - Call `start_scan_job` without a `device_id` to auto-select a scanner and begin scanning.
 - Artifacts are written under `INBOX_DIR` per job: `job-*/page_*.tiff`, `doc_*.tiff`, `manifest.json`, `events.jsonl`.
+
+## Streamable HTTP transport
+
+Prefer to keep the scanner attached to another machine while still avoiding any cloud round-trips? `scan-mcp` exposes the
+streamable HTTP transport as a first-class option:
+
+```bash
+scan-mcp --http
+```
+
+- Default port is `3001`; set `MCP_HTTP_PORT` to override (for example `MCP_HTTP_PORT=3333 scan-mcp --http`).
+- The server still reads and writes entirely on the host where it runs—no remote storage or relays.
+- HTTP responses use server-sent events (SSE) for streaming tool output; clients such as Claude Desktop and Windsurf support
+  this transport.
 
 ## Install
 
 - Run with npx: `npx scan-mcp` (recommended)
   - The CLI runs a quick preflight check for Node 22+ and required scanner/image tools and prints installation hints if anything is missing.
   - See recommended server config above
+- Use `npx scan-mcp --http` to launch the streamable HTTP transport when running on another machine.
 - CLI help: `scan-mcp --help`
 - From source (for development):
   - `npm install`
@@ -70,6 +87,41 @@ Add a server entry to your MCP client configuration:
 - `SCAN_EXCLUDE_BACKENDS` (CSV): backends to exclude (e.g., `v4l`).
 - `SCAN_PREFER_BACKENDS` (CSV): preferred backends (e.g., `epjitsu,epson2`).
 - `PERSIST_LAST_USED_DEVICE` (default: `true`): persist and lightly prefer last used device.
+- `MCP_HTTP_PORT` (default: `3001`): TCP port for the HTTP transport.
+
+## Raspberry Pi / detached Linux over HTTP
+
+Many workflows keep the scanner plugged into a low-power machine (Raspberry Pi, Intel NUC, home server) tucked away in another
+room. Run `scan-mcp` directly on that hardware and connect to it over your LAN while keeping every scan on devices you control.
+
+1. Install the prerequisites (`node >= 22`, SANE, TIFF tooling) on the detached machine. Consider enabling `systemd` or `tmux`
+   so the process stays alive when you disconnect.
+2. Start the HTTP transport where the scanner is attached:
+
+   ```bash
+   INBOX_DIR=/mnt/scans/inbox MCP_HTTP_PORT=3001 scan-mcp --http
+   ```
+
+3. On your desktop, point your MCP client at the HTTP endpoint. Claude Desktop-style configuration:
+
+   ```json
+   {
+     "mcpServers": {
+       "scan-remote": {
+         "transport": {
+           "type": "http",
+           "url": "http://raspberrypi.local:3001/mcp"
+         },
+         "env": {
+           "SCAN_MOCK": "false"
+         }
+       }
+     }
+   }
+   ```
+
+This keeps capture, processing, and storage on your local machines—the MCP client simply streams tool calls over HTTP on your
+network.
 
 ## API
 
@@ -141,7 +193,7 @@ Defaults aim for 300dpi, reasonable color mode, and ADF/duplex when available. F
 
 ## Development
 
-- `npm run dev` (stdio MCP server), `npm run dev:http` (experimental HTTP)
+- `npm run dev` (stdio MCP server), `npm run dev:http` (HTTP transport)
 - `make verify` runs lint, typecheck, and tests
 - Conventions: `docs/CONVENTIONS.md` and architecture in `docs/BLUEPRINT.md`
 

--- a/README.md
+++ b/README.md
@@ -49,17 +49,17 @@ Add a server entry to your MCP client configuration:
 
 ## Streamable HTTP transport
 
-Prefer to keep the scanner attached to another machine while still avoiding any cloud round-trips? `scan-mcp` exposes the
-streamable HTTP transport as a first-class option:
+Prefer to attach the scanner to another machine on your network? `scan-mcp` also supports the
+streamable HTTP transport:
 
 ```bash
 scan-mcp --http
 ```
 
 - Default port is `3001`; set `MCP_HTTP_PORT` to override (for example `MCP_HTTP_PORT=3333 scan-mcp --http`).
-- The server still reads and writes entirely on the host where it runs—no remote storage or relays.
 - HTTP responses use server-sent events (SSE) for streaming tool output; clients such as Claude Desktop and Windsurf support
   this transport.
+- There is currently no authentication; this is intended for internal LAN networking
 
 ## Install
 
@@ -88,40 +88,6 @@ scan-mcp --http
 - `SCAN_PREFER_BACKENDS` (CSV): preferred backends (e.g., `epjitsu,epson2`).
 - `PERSIST_LAST_USED_DEVICE` (default: `true`): persist and lightly prefer last used device.
 - `MCP_HTTP_PORT` (default: `3001`): TCP port for the HTTP transport.
-
-## Raspberry Pi / detached Linux over HTTP
-
-Many workflows keep the scanner plugged into a low-power machine (Raspberry Pi, Intel NUC, home server) tucked away in another
-room. Run `scan-mcp` directly on that hardware and connect to it over your LAN while keeping every scan on devices you control.
-
-1. Install the prerequisites (`node >= 22`, SANE, TIFF tooling) on the detached machine. Consider enabling `systemd` or `tmux`
-   so the process stays alive when you disconnect.
-2. Start the HTTP transport where the scanner is attached:
-
-   ```bash
-   INBOX_DIR=/mnt/scans/inbox MCP_HTTP_PORT=3001 scan-mcp --http
-   ```
-
-3. On your desktop, point your MCP client at the HTTP endpoint. Claude Desktop-style configuration:
-
-   ```json
-   {
-     "mcpServers": {
-       "scan-remote": {
-         "transport": {
-           "type": "http",
-           "url": "http://raspberrypi.local:3001/mcp"
-         },
-         "env": {
-           "SCAN_MOCK": "false"
-         }
-       }
-     }
-   }
-   ```
-
-This keeps capture, processing, and storage on your local machines—the MCP client simply streams tool calls over HTTP on your
-network.
 
 ## API
 

--- a/bin/scan-mcp
+++ b/bin/scan-mcp
@@ -4,8 +4,65 @@
 import pkg from '../package.json' with { type: 'json' };
 
 const args = process.argv.slice(2);
-const wantsHelp = args.includes('-h') || args.includes('--help') || args.includes('help');
-const wantsVersion = args.includes('-v') || args.includes('--version') || args.includes('version');
+
+function parseArgs(rawArgs) {
+  let wantsHelp = false;
+  let wantsVersion = false;
+  let transport = 'stdio';
+
+  const parseTransport = (value) => {
+    const normalized = String(value || '').toLowerCase();
+    if (normalized === 'stdio') return 'stdio';
+    if (normalized === 'http' || normalized === 'streamable-http') return 'http';
+    throw new Error(`Unknown transport '${value}'. Supported transports: stdio, http.`);
+  };
+
+  for (let i = 0; i < rawArgs.length; i += 1) {
+    const arg = rawArgs[i];
+    if (arg === '-h' || arg === '--help' || arg === 'help') {
+      wantsHelp = true;
+      continue;
+    }
+    if (arg === '-v' || arg === '--version' || arg === 'version') {
+      wantsVersion = true;
+      continue;
+    }
+    if (arg === '--http') {
+      transport = 'http';
+      continue;
+    }
+    if (arg === '--stdio') {
+      transport = 'stdio';
+      continue;
+    }
+    if (arg === '--transport') {
+      const value = rawArgs[i + 1];
+      if (!value) {
+        throw new Error('Missing value for --transport.');
+      }
+      transport = parseTransport(value);
+      i += 1;
+      continue;
+    }
+    if (arg && arg.startsWith('--transport=')) {
+      const value = arg.slice('--transport='.length);
+      transport = parseTransport(value);
+      continue;
+    }
+  }
+
+  return { wantsHelp, wantsVersion, transport };
+}
+
+let parsed;
+try {
+  parsed = parseArgs(args);
+} catch (error) {
+  console.error(String(error instanceof Error ? error.message : error));
+  process.exit(1);
+}
+
+const { wantsHelp, wantsVersion, transport } = parsed;
 
 const version = (pkg && pkg.version) || process.env.npm_package_version || 'unknown';
 
@@ -14,10 +71,18 @@ if (wantsHelp) {
 scan-mcp v${version}
 
 Usage:
-  scan-mcp [--help]
+  scan-mcp [--transport <stdio|http>]
+  scan-mcp --http
+  scan-mcp --help
+  scan-mcp --version
 
 Description:
   Minimal MCP server for scanner capture (ADF/duplex/page-size), batching, and multipage assembly.
+  Default transport is stdio for local-first, privacy-first operation. Use --http for a streamable HTTP server.
+
+Transports:
+  stdio (default)          Direct stdio bridge for local MCP clients.
+  http                     Streamable HTTP/SSE server (set MCP_HTTP_PORT to change the port, default 3001).
 
 Environment:
   SCAN_MOCK                Mock SANE; generate fake TIFFs (default: false)
@@ -29,12 +94,16 @@ Environment:
   SCAN_EXCLUDE_BACKENDS    CSV backends to exclude (e.g., v4l)
   SCAN_PREFER_BACKENDS     CSV backends to prefer (e.g., epjitsu,epson2)
   PERSIST_LAST_USED_DEVICE Persist and prefer last used device (default: true)
+  MCP_HTTP_PORT            TCP port when using --http (default: 3001)
 
 Examples:
-  # Run directly
+  # Run locally over stdio (default)
   scan-mcp
 
-  # Via npx in MCP client config
+  # Start the HTTP transport on port 3333
+  MCP_HTTP_PORT=3333 scan-mcp --http
+
+  # Via npx in MCP client config (stdio)
   {
     "mcpServers": {
       "scan": { "command": "npx", "args": ["scan-mcp"] }
@@ -72,6 +141,17 @@ async function bootstrap() {
   }
 
   try {
+    if (transport === 'http') {
+      const mod = await import('../dist/http-server.js');
+      if (typeof mod.startHttpServer !== 'function') {
+        console.error('scan-mcp HTTP entrypoint missing startHttpServer() export');
+        process.exit(1);
+        return;
+      }
+      mod.startHttpServer();
+      return;
+    }
+
     const mod = await import('../dist/mcp.js');
     if (typeof mod.main !== 'function') {
       console.error('scan-mcp entrypoint missing main() export');

--- a/llms-install.md
+++ b/llms-install.md
@@ -50,27 +50,6 @@ Key details:
 - Set `SCAN_MOCK=true` in the `env` block when running on a machine without SANE devices.
 - Additional overrides such as `SCANIMAGE_BIN`, `TIFFCP_BIN`, or `SCAN_PREFER_BACKENDS` can also be supplied inside the same `env` object when needed.
 
-### Streamable HTTP transport
-
-When the scanner is attached to another machine (for example a Raspberry Pi on your local network), start the server with `npx
-scan-mcp --http` on that host and point your MCP client at `http://<hostname>:3001/mcp`. Claude Desktop accepts a block like:
-
-```json
-{
-  "mcpServers": {
-    "scan-remote": {
-      "transport": {
-        "type": "http",
-        "url": "http://raspberrypi.local:3001/mcp"
-      }
-    }
-  }
-}
-```
-
-This keeps the workflow local-first: capture happens on the detached machine, and your desktop communicates directly with it ov
-er your LAN without passing data through third-party services.
-
 ## Verification Steps
 
 1. Ensure the inbox directory exists and is writable.

--- a/llms-install.md
+++ b/llms-install.md
@@ -50,6 +50,27 @@ Key details:
 - Set `SCAN_MOCK=true` in the `env` block when running on a machine without SANE devices.
 - Additional overrides such as `SCANIMAGE_BIN`, `TIFFCP_BIN`, or `SCAN_PREFER_BACKENDS` can also be supplied inside the same `env` object when needed.
 
+### Streamable HTTP transport
+
+When the scanner is attached to another machine (for example a Raspberry Pi on your local network), start the server with `npx
+scan-mcp --http` on that host and point your MCP client at `http://<hostname>:3001/mcp`. Claude Desktop accepts a block like:
+
+```json
+{
+  "mcpServers": {
+    "scan-remote": {
+      "transport": {
+        "type": "http",
+        "url": "http://raspberrypi.local:3001/mcp"
+      }
+    }
+  }
+}
+```
+
+This keeps the workflow local-first: capture happens on the detached machine, and your desktop communicates directly with it ov
+er your LAN without passing data through third-party services.
+
 ## Verification Steps
 
 1. Ensure the inbox directory exists and is writable.


### PR DESCRIPTION
## Summary
- add CLI parsing to select stdio (default) or HTTP transport and expand CLI help text
- document HTTP usage, Raspberry Pi deployment, and environment variables in README
- update llms-install guide with HTTP configuration example for remote hosts

## Testing
- npm run lint
- npm run typecheck
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68cc6d606670832eb13e0a95848ce379