### PR TITLE
fix: remove orientation fallback tool

### DIFF
--- a/src/server/register.ts
+++ b/src/server/register.ts
@@ -119,19 +119,6 @@ export function registerScanServer(server: McpServer, ctx: AppContext) {
     }
   );
 
-  server.tool(
-    "Start Here for ScanServerOrientation",
-    "Compatibility fallback: returns full orientation document; prefer resources and prompts",
-    async () => ({
-      content: [
-        {
-          type: "text",
-          text: `URI: ${orientationUri}\n\n${orientationText}`,
-        },
-      ],
-    })
-  );
-
   server.prompt(
     "bootstrap_context",
     "Initialize Context",

--- a/src/tests/register.test.ts
+++ b/src/tests/register.test.ts
@@ -42,7 +42,6 @@ describe("registerScanServer", () => {
         "list_jobs",
         "get_manifest",
         "get_events",
-        "Start Here for ScanServerOrientation",
       ])
     );
     const resources = Object.keys(internal._registeredResourceTemplates);


### PR DESCRIPTION
## Summary
- remove the legacy "Start Here for ScanServerOrientation" tool registration
- update the registration test to match the remaining tool list

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ccdbda14e4832e9a94510fda6a3dd3