### PR TITLE
feat: add Claude Code skills for scan-mcp

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,13 @@
+{
+  "permissions": {
+    "allow": [
+      "Skill(skill-builder)",
+      "Skill(scan)",
+      "Bash(claude mcp call scan-mcp start_scan_job '{}')",
+      "Bash(node bin/scan-mcp:*)",
+      "Skill(setup-mcp)",
+      "mcp__scan__start_scan_job",
+      "mcp__scan__get_job_status"
+    ]
+  }
+}

--- a/.claude/skills/scan/CONFIG.md
+++ b/.claude/skills/scan/CONFIG.md
@@ -1,0 +1,205 @@
+# scan-mcp Configuration
+
+Environment variables and configuration options for the scan-mcp MCP server.
+
+## Contents
+
+- [Core Configuration](#core-configuration)
+- [Device Selection Tuning](#device-selection-tuning)
+- [Binary Path Overrides](#binary-path-overrides)
+- [Testing and Development](#testing-and-development)
+- [Device Auto-Selection Details](#device-auto-selection-details)
+
+---
+
+## Core Configuration
+
+### INBOX_DIR
+
+Base directory for job runs and artifacts.
+
+- **Default**: `scanned_documents/inbox` (relative to current directory)
+- **Example**: `~/Documents/scanned_documents/inbox`
+- **Note**: Directory will be created if it doesn't exist
+
+**MCP config example**:
+```json
+{
+  "mcpServers": {
+    "scan": {
+      "command": "npx",
+      "args": ["-y", "scan-mcp"],
+      "env": {
+        "INBOX_DIR": "~/Documents/scanned_documents/inbox"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Device Selection Tuning
+
+### SCAN_EXCLUDE_BACKENDS
+
+Comma-separated list of backends to exclude from device selection.
+
+- **Default**: Excludes camera backends like `v4l`
+- **Example**: `v4l,test`
+
+**Use case**: Prevent auto-selection of webcams or test devices.
+
+### SCAN_PREFER_BACKENDS
+
+Comma-separated list of preferred backends (lightly boosted in scoring).
+
+- **Default**: None
+- **Example**: `epson2,fujitsu`
+
+**Use case**: Favor specific scanner brands when multiple devices available.
+
+### PERSIST_LAST_USED_DEVICE
+
+Persist and lightly prefer last-used device.
+
+- **Default**: `true`
+- **Values**: `true` | `false`
+
+**Use case**: Disable if you want truly neutral device selection each time.
+
+**MCP config example**:
+```json
+{
+  "mcpServers": {
+    "scan": {
+      "command": "npx",
+      "args": ["-y", "scan-mcp"],
+      "env": {
+        "INBOX_DIR": "~/Documents/scanned_documents/inbox",
+        "SCAN_PREFER_BACKENDS": "epson2,fujitsu",
+        "SCAN_EXCLUDE_BACKENDS": "v4l,test",
+        "PERSIST_LAST_USED_DEVICE": "true"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Binary Path Overrides
+
+Override paths to scanner and image processing binaries.
+
+### SCANIMAGE_BIN
+
+- **Default**: `scanimage`
+- **Example**: `/usr/local/bin/scanimage`
+
+### SCANADF_BIN
+
+- **Default**: `scanadf`
+- **Example**: `/usr/local/bin/scanadf`
+
+### TIFFCP_BIN
+
+- **Default**: `tiffcp`
+- **Example**: `/opt/local/bin/tiffcp`
+
+### IM_CONVERT_BIN
+
+- **Default**: `convert`
+- **Example**: `/usr/local/bin/convert`
+
+**Use case**: Custom SANE installations or non-standard paths.
+
+**MCP config example**:
+```json
+{
+  "mcpServers": {
+    "scan": {
+      "command": "npx",
+      "args": ["-y", "scan-mcp"],
+      "env": {
+        "INBOX_DIR": "~/Documents/scanned_documents/inbox",
+        "SCANIMAGE_BIN": "/usr/local/bin/scanimage",
+        "TIFFCP_BIN": "/opt/local/bin/tiffcp"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Testing and Development
+
+### SCAN_MOCK
+
+Mock SANE calls and generate fake TIFFs for testing.
+
+- **Default**: `false`
+- **Values**: `true` | `false`
+
+**Use case**: Testing without physical scanner hardware.
+
+**MCP config example**:
+```json
+{
+  "mcpServers": {
+    "scan": {
+      "command": "npx",
+      "args": ["-y", "scan-mcp"],
+      "env": {
+        "INBOX_DIR": "~/Documents/scanned_documents/inbox",
+        "SCAN_MOCK": "true"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Device Auto-Selection Details
+
+When `device_id` is not specified, the server ranks candidates by:
+
+1. **Backend exclusions**: Excludes backends in `SCAN_EXCLUDE_BACKENDS`
+2. **Feeder preference**: Devices with ADF get a boost
+3. **Duplex capability**: Extra points for `ADF Duplex` support
+4. **Resolution match**: Small bump if device supports the desired resolution
+5. **Backend preference**: Small bump for backends in `SCAN_PREFER_BACKENDS`
+6. **Last used**: Light bump for the last-used device (if persistence enabled)
+7. **Tie-break**: Score descending, then `deviceId` lexicographically
+
+---
+
+## Multiple MCP Server Configurations
+
+You can configure multiple scan-mcp instances with different settings:
+
+```json
+{
+  "mcpServers": {
+    "scan-personal": {
+      "command": "npx",
+      "args": ["-y", "scan-mcp"],
+      "env": {
+        "INBOX_DIR": "~/Documents/personal/scans"
+      }
+    },
+    "scan-work": {
+      "command": "npx",
+      "args": ["-y", "scan-mcp"],
+      "env": {
+        "INBOX_DIR": "~/Documents/work/scans",
+        "SCAN_PREFER_BACKENDS": "fujitsu"
+      }
+    }
+  }
+}
+```
+
+Then specify which server to use: "Use scan-work to scan this"

--- a/.claude/skills/scan/EXAMPLES.md
+++ b/.claude/skills/scan/EXAMPLES.md
@@ -1,0 +1,236 @@
+# User Intent → Parameter Examples
+
+Detailed mappings from user requests to scan-mcp parameters.
+
+## General Rule
+
+If the user is vague, use `{}`. If the user's intent implies specific requirements, override only those parameters.
+
+---
+
+## Generic Scan Requests
+
+**User says**: "Scan this", "Start a scan", "Scan the document"
+
+**Action**: `start_scan_job({})`
+
+**Reasoning**: Trust server defaults—300 dpi, Lineart, ADF Duplex with auto-selected device.
+
+---
+
+## Photo Scanning
+
+**User says**: "Scan this photo", "High-quality photo scan", "Scan a picture"
+
+**Parameters**:
+```json
+{
+  "source": "Flatbed",
+  "color_mode": "Color",
+  "resolution_dpi": 600
+}
+```
+
+**Reasoning**: Photos need flatbed (single-page), full color, and high resolution.
+
+**Variation**: "Highest quality scan"
+```json
+{
+  "source": "Flatbed",
+  "color_mode": "Color",
+  "resolution_dpi": 1200
+}
+```
+
+---
+
+## Duplex Stack Scanning
+
+**User says**: "Scan a stack double-sided", "Use the feeder, both sides", "Scan these duplex"
+
+**Parameters**:
+```json
+{
+  "duplex": true
+}
+```
+
+**Reasoning**: `duplex: true` nudges server toward ADF Duplex. Let server handle other defaults.
+
+**Variation**: "Scan these pages front and back in color"
+```json
+{
+  "duplex": true,
+  "color_mode": "Color"
+}
+```
+
+---
+
+## OCR-Optimized Scanning
+
+**User says**: "Scan text for OCR", "Scan document for text extraction"
+
+**Parameters**:
+```json
+{
+  "resolution_dpi": 300,
+  "color_mode": "Gray"
+}
+```
+
+**Reasoning**: 300 dpi is optimal for OCR. Gray mode provides better quality than Lineart while remaining compact.
+
+---
+
+## Specific Scanner Selection
+
+**User says**: "Use the Epson scanner", "Scan with the HP", "What scanners do I have?"
+
+**Strategy**:
+1. Call `list_devices()` to enumerate available scanners
+2. Identify the device matching user's request
+3. Call `start_scan_job({ device_id: "..." })` with the matched device
+
+**Example**:
+```javascript
+// 1. List devices
+const devices = await list_devices();
+
+// 2. Find Epson scanner
+const epson = devices.find(d =>
+  d.backend === 'epson2' || d.model.toLowerCase().includes('epson')
+);
+
+// 3. Start scan with specific device
+await start_scan_job({ device_id: epson.deviceId });
+```
+
+---
+
+## Receipts and Small Documents
+
+**User says**: "Scan this receipt", "Scan a business card", "Scan a note"
+
+**Parameters**: `{}` or optionally:
+```json
+{
+  "source": "Flatbed"
+}
+```
+
+**Reasoning**: Small documents work fine with defaults. Flatbed preferred for delicate items.
+
+---
+
+## Large Format Documents
+
+**User says**: "Scan legal-size document", "Scan A4 paper"
+
+**Parameters**:
+```json
+{
+  "page_size": "Legal"
+}
+```
+
+or
+
+```json
+{
+  "page_size": "A4"
+}
+```
+
+**Reasoning**: Explicit page size ensures scanner uses correct scan area.
+
+---
+
+## Draft/Quick Scans
+
+**User says**: "Quick scan", "Draft quality", "Fast scan"
+
+**Parameters**:
+```json
+{
+  "resolution_dpi": 150
+}
+```
+
+**Reasoning**: Lower resolution scans faster, smaller files. Good for previews.
+
+---
+
+## Archival/High-Quality Documents
+
+**User says**: "Archival scan", "Highest quality", "Preserve all detail"
+
+**Parameters**:
+```json
+{
+  "resolution_dpi": 1200,
+  "color_mode": "Color"
+}
+```
+
+**Reasoning**: Maximum resolution and full color for preservation purposes.
+
+---
+
+## Mixed Document Stacks
+
+**User says**: "Scan these mixed documents", "Batch scan these pages"
+
+**Parameters**: `{}` or:
+```json
+{
+  "duplex": false
+}
+```
+
+**Reasoning**: Defaults work well. Specify `duplex: false` to use single-sided ADF if documents vary in thickness.
+
+---
+
+## Flatbed-Only Requests
+
+**User says**: "Use the flatbed", "Scan from the glass"
+
+**Parameters**:
+```json
+{
+  "source": "Flatbed"
+}
+```
+
+**Reasoning**: User explicitly requested flatbed source.
+
+---
+
+## Color Preservation
+
+**User says**: "Scan in color", "Preserve colors", "Color scan"
+
+**Parameters**:
+```json
+{
+  "color_mode": "Color"
+}
+```
+
+**Reasoning**: User explicitly wants color output.
+
+---
+
+## Black and White Documents
+
+**User says**: "Black and white scan", "Text only", "No color needed"
+
+**Parameters**: `{}` (defaults to Lineart) or explicitly:
+```json
+{
+  "color_mode": "Lineart"
+}
+```
+
+**Reasoning**: Lineart provides smallest files for pure text documents.

--- a/.claude/skills/scan/SKILL.md
+++ b/.claude/skills/scan/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: scan
+description: Control scanners via scan-mcp MCP server to capture documents, photos, receipts, and pages. Use when user mentions scanning, scanners, or document types. CRITICAL: call start_scan_job with {} (no params) unless user specifies requirements—server handles intelligent device selection and defaults. Override only for explicit needs like photos (Flatbed+Color+high-res) or duplex stacks (ADF Duplex).
+---
+
+# Scanner Control via scan-mcp
+
+## THE GOLDEN RULE
+
+**Trust the server defaults.** When the user requests a scan without specific requirements:
+- Call `start_scan_job({})` with NO parameters
+- Do NOT call `list_devices` unless the user explicitly asks for a specific scanner
+- Do NOT gather device capabilities "just in case"
+- Server auto-selects device, resolution (300dpi), color mode (Lineart), source (ADF Duplex → ADF → Flatbed)
+
+**Only override parameters when the user's intent clearly requires it.**
+
+## Decision Tree
+
+```
+User request → Analyze intent:
+
+1. Generic scan ("scan this", "scan document")
+   → start_scan_job({}) immediately
+
+2. User asks for specific scanner ("use the Epson")
+   → list_devices, then start_scan_job({ device_id })
+
+3. Document type needs special handling ("photo", "duplex")
+   → Override only specific params needed
+```
+
+## Common Overrides
+
+| User Intent | Parameters |
+|------------|------------|
+| Generic scan | `{}` |
+| Photo scan | `{ source: "Flatbed", color_mode: "Color", resolution_dpi: 600 }` |
+| Duplex stack | `{ duplex: true }` |
+| OCR-optimized | `{ color_mode: "Gray", resolution_dpi: 300 }` |
+
+**For more mappings**, see [EXAMPLES.md](EXAMPLES.md).
+
+## Standard Workflow
+
+1. Call `start_scan_job(params)` → receive `{ job_id, run_dir, state }`
+2. Poll `get_job_status({ job_id })` until `state: "completed"`
+3. Results in `run_dir`:
+   - `page_*.tiff` (captured pages)
+   - `doc_*.tiff` (assembled document)
+   - `manifest.json` (metadata)
+   - `events.jsonl` (event log)
+
+## Quick Troubleshooting
+
+**If scan fails:**
+1. `get_manifest({ job_id })` — check state and parameters
+2. `get_events({ job_id })` — find error details in `scanner_failed` events
+3. Common fixes:
+   - "No devices" → Ask user to check scanner power/connection
+   - "Feeder jam" → Try `{ source: "Flatbed" }`
+
+**For detailed troubleshooting**, see [TROUBLESHOOTING.md](TROUBLESHOOTING.md).
+
+## Reference Materials
+
+- **[TOOLS.md](TOOLS.md)** — Complete tool reference with all parameters
+- **[EXAMPLES.md](EXAMPLES.md)** — User intent → parameter mappings with reasoning
+- **[TROUBLESHOOTING.md](TROUBLESHOOTING.md)** — Detailed troubleshooting flows
+- **[CONFIG.md](CONFIG.md)** — Environment variables and configuration

--- a/.claude/skills/scan/TOOLS.md
+++ b/.claude/skills/scan/TOOLS.md
@@ -1,0 +1,216 @@
+# scan-mcp Tool Reference
+
+Complete reference for all scan-mcp MCP tools.
+
+## Contents
+
+- [list_devices](#list_devices)
+- [get_device_options](#get_device_options)
+- [start_scan_job](#start_scan_job)
+- [get_job_status](#get_job_status)
+- [cancel_job](#cancel_job)
+- [list_jobs](#list_jobs)
+- [get_manifest](#get_manifest)
+- [get_events](#get_events)
+
+---
+
+## list_devices
+
+Enumerate connected scanners and basic capabilities.
+
+**Inputs**: None
+
+**Returns**:
+```json
+[
+  {
+    "deviceId": "epson2:libusb:001:003",
+    "backend": "epson2",
+    "model": "Epson Perfection V550",
+    "type": "scanner"
+  }
+]
+```
+
+**When to use**: Only when user explicitly asks for available scanners or specifies a particular scanner.
+
+---
+
+## get_device_options
+
+Get detailed options (sources, resolutions, modes) for a specific device.
+
+**Inputs**:
+- `device_id` (string, required): Target device identifier
+
+**Returns**:
+```json
+{
+  "deviceId": "epson2:libusb:001:003",
+  "sources": ["Flatbed", "ADF", "ADF Duplex"],
+  "resolutions": [150, 300, 600, 1200],
+  "colorModes": ["Lineart", "Gray", "Color"]
+}
+```
+
+**When to use**: For troubleshooting or when user asks about scanner capabilities.
+
+---
+
+## start_scan_job
+
+Begin a scanning job. **Omitting parameters triggers auto-selection and defaults.**
+
+**Inputs** (all optional):
+- `device_id` (string): Specific scanner; otherwise auto-select
+- `resolution_dpi` (integer, 50-1200): Target DPI (default: 300)
+- `color_mode` (string): `Lineart` | `Gray` | `Halftone` | `Color` (default: Lineart)
+- `source` (string): `Flatbed` | `ADF` | `ADF Duplex` (default: ADF Duplex)
+- `duplex` (boolean): Prefer ADF Duplex if available
+- `page_size` (string): `Letter` | `A4` | `Legal` | `Custom`
+- `custom_size_mm` (object): `{ width: number, height: number }`
+- `doc_break_policy` (object): Advanced per-page splitting config
+- `tmp_dir` (string): Override base directory for run_dir
+
+**Returns**:
+```json
+{
+  "job_id": "job-20250812-143022-abc123",
+  "run_dir": "/path/to/inbox/job-20250812-143022-abc123",
+  "state": "running"
+}
+```
+
+**Default behavior** (when called with `{}`):
+- Resolution: 300 dpi (probed and normalized)
+- Color mode: Lineart → Gray → Halftone → Color (first available)
+- Source: ADF Duplex → ADF → Flatbed (first available)
+- Device: Auto-selected based on scoring (prefers ADF/duplex)
+
+---
+
+## get_job_status
+
+Inspect job state and artifact counts.
+
+**Inputs**:
+- `job_id` (string, required): Job identifier
+
+**Returns**:
+```json
+{
+  "job_id": "job-20250812-143022-abc123",
+  "state": "completed",
+  "page_count": 5,
+  "doc_count": 1,
+  "run_dir": "/path/to/inbox/job-20250812-143022-abc123"
+}
+```
+
+**When to use**: Poll until `state` is `completed` or `error`.
+
+---
+
+## cancel_job
+
+Request job cancellation (best effort during scan loops).
+
+**Inputs**:
+- `job_id` (string, required): Job identifier
+
+**Returns**:
+```json
+{
+  "job_id": "job-20250812-143022-abc123",
+  "state": "cancelled"
+}
+```
+
+---
+
+## list_jobs
+
+List recent jobs from the inbox directory.
+
+**Inputs** (optional):
+- `limit` (integer, max 100): Number of jobs to return
+- `state` (string): Filter by state (`running` | `completed` | `cancelled` | `error` | `unknown`)
+
+**Returns**:
+```json
+[
+  {
+    "job_id": "job-20250812-143022-abc123",
+    "state": "completed",
+    "created_at": "2025-08-12T14:30:22Z"
+  }
+]
+```
+
+---
+
+## get_manifest
+
+Fetch a job's `manifest.json`.
+
+**Inputs**:
+- `job_id` (string, required): Job identifier
+
+**Returns**: Raw manifest JSON containing:
+- Job metadata (ID, state, timestamps)
+- Parameters used for the scan
+- Page and document listings
+- Error details (if applicable)
+
+**When to use**: To inspect job configuration, verify parameters, or check error states.
+
+---
+
+## get_events
+
+Retrieve a job's `events.jsonl` log.
+
+**Inputs**:
+- `job_id` (string, required): Job identifier
+
+**Returns**: Raw events JSONL with chronological events:
+- `job_started`: Job initialization
+- `scanner_exec`: Scanner command execution
+- `scanner_failed`: Errors during scanning (with retry details)
+- `job_completed`: Successful completion
+- `job_failed`: Terminal errors
+
+**When to use**: To debug failures, understand scan timeline, or find error details.
+
+---
+
+## Parameter Details
+
+### resolution_dpi
+
+- **Default**: 300 dpi (probed and normalized to nearest available)
+- **Range**: 50-1200
+- **Common values**: 150 (draft), 300 (standard), 600 (photos), 1200 (archival)
+
+### color_mode
+
+- **Default**: Lineart (fallback: Lineart → Gray → Halftone → Color)
+- **Values**: `Lineart`, `Gray`, `Halftone`, `Color`
+- **Case-insensitive**: Server normalizes to device's exact naming
+
+### source
+
+- **Default**: ADF Duplex (fallback: ADF Duplex → ADF → Flatbed)
+- **Values**: `Flatbed`, `ADF`, `ADF Duplex`
+
+### duplex
+
+- **Default**: `false`
+- **Effect**: When `true`, nudges source selection toward `ADF Duplex` if available
+
+### page_size
+
+- **Default**: None (scanner's default)
+- **Values**: `Letter`, `A4`, `Legal`, `Custom`
+- **Custom**: Requires `custom_size_mm: { width, height }`

--- a/.claude/skills/scan/TROUBLESHOOTING.md
+++ b/.claude/skills/scan/TROUBLESHOOTING.md
@@ -1,0 +1,247 @@
+# Troubleshooting scan-mcp
+
+Systematic troubleshooting guide for scan failures and issues.
+
+## Contents
+
+- [Troubleshooting Flow](#troubleshooting-flow)
+- [Common Issues](#common-issues)
+- [Retry Strategies](#retry-strategies)
+- [Diagnostic Commands](#diagnostic-commands)
+
+---
+
+## Troubleshooting Flow
+
+When a scan fails or behaves unexpectedly:
+
+### Step 1: Inspect Manifest and Events
+
+**Get the manifest**:
+```javascript
+const manifest = await get_manifest({ job_id });
+```
+
+Check:
+- `state`: Is it `error`, `cancelled`, or stuck in `running`?
+- `params`: Were the parameters applied correctly?
+- `device`: Which device was selected?
+
+**Get the events**:
+```javascript
+const events = await get_events({ job_id });
+```
+
+Look for `scanner_failed` events with:
+- `exit_code`: Scanner process exit code
+- `signal`: Signal that terminated the process (if any)
+- `command`: Exact scanner command executed
+- `stderr_tail`: Last lines of error output
+
+### Step 2: Examine Scanner Logs
+
+The server writes logs to the `run_dir`:
+- `scanner.out.log`: Standard output from scanner command
+- `scanner.err.log`: Error output from scanner command
+
+Events include tails of both files on failure.
+
+### Step 3: Apply Solutions
+
+See [Common Issues](#common-issues) below for specific error patterns and fixes.
+
+### Step 4: Retry if Appropriate
+
+See [Retry Strategies](#retry-strategies) for transient failures.
+
+---
+
+## Common Issues
+
+### "No devices found"
+
+**Symptoms**: `list_devices` returns empty array or `start_scan_job` fails with device error.
+
+**Solutions**:
+1. Ask user to verify scanner is powered on and connected (USB/network)
+2. Check if SANE is installed: User should verify with `scanimage -L`
+3. Verify USB permissions (user may need to be in `scanner` or `lp` group)
+4. Try specifying a device explicitly if auto-selection fails
+
+---
+
+### "Unsupported resolution/mode"
+
+**Symptoms**: Scanner rejects the resolution or color mode.
+
+**Solutions**:
+1. Server auto-normalizes when possible, but check device capabilities:
+   ```javascript
+   const options = await get_device_options({ device_id });
+   ```
+2. Re-issue `start_scan_job` with a supported value from `options`
+3. If not using `device_id`, trust auto-selection (it will pick supported values)
+
+---
+
+### "Feeder jam or empty"
+
+**Symptoms**: Events show `scanner_failed` with feeder-related errors.
+
+**Solutions**:
+1. Ask user to check the ADF for paper jams or empty tray
+2. Suggest reloading paper and retrying
+3. If issue persists, switch to flatbed:
+   ```javascript
+   await start_scan_job({ source: "Flatbed" });
+   ```
+
+---
+
+### "Permission denied on device or tmp_dir"
+
+**Symptoms**: Events show permission errors accessing scanner device or writing to `run_dir`.
+
+**Solutions**:
+1. User needs permissions to access scanner device
+2. Check `INBOX_DIR` location and permissions
+3. Try setting `tmp_dir` to a location with write access:
+   ```javascript
+   await start_scan_job({ tmp_dir: "/tmp/scans" });
+   ```
+
+---
+
+### "Job stuck in 'running' state"
+
+**Symptoms**: `get_job_status` shows `state: "running"` indefinitely.
+
+**Solutions**:
+1. Cancel the job: `await cancel_job({ job_id })`
+2. Check if scanner process is hung (examine logs)
+3. Ask user to power cycle the scanner and retry
+
+---
+
+### "Wrong device selected"
+
+**Symptoms**: Server selected unexpected device.
+
+**Solutions**:
+1. Explicitly specify device:
+   ```javascript
+   const devices = await list_devices();
+   // User selects desired device
+   await start_scan_job({ device_id: devices[0].deviceId });
+   ```
+2. Or configure backend preferences in server config (see CONFIG.md)
+
+---
+
+### "Low quality or wrong color mode"
+
+**Symptoms**: Output quality doesn't match expectations.
+
+**Solutions**:
+1. Check what mode was actually used in manifest
+2. Explicitly specify desired mode:
+   ```javascript
+   await start_scan_job({ color_mode: "Color", resolution_dpi: 600 });
+   ```
+
+---
+
+### "Pages missing from output"
+
+**Symptoms**: Fewer pages captured than expected.
+
+**Solutions**:
+1. Check `manifest.json` for page count
+2. Verify feeder didn't jam mid-scan (check events)
+3. For flatbed: User may need to scan again with source change
+4. Retry scan
+
+---
+
+## Retry Strategies
+
+### Transient Failures
+
+If failure looks transient (paper jam, timeout, device busy):
+
+**Retry with same parameters**:
+```javascript
+await start_scan_job(originalParams);
+```
+
+### Performance Issues
+
+**Lower resolution if timeout/performance issues**:
+```javascript
+await start_scan_job({
+  ...originalParams,
+  resolution_dpi: 150
+});
+```
+
+### Feeder Problems
+
+**Switch sources if feeder fails**:
+```javascript
+await start_scan_job({
+  ...originalParams,
+  source: "Flatbed"
+});
+```
+
+### Device Selection Issues
+
+**Try different device**:
+```javascript
+const devices = await list_devices();
+await start_scan_job({
+  ...originalParams,
+  device_id: devices[1].deviceId  // Try second device
+});
+```
+
+---
+
+## Diagnostic Commands
+
+When troubleshooting, these commands help understand state:
+
+**Check job state**:
+```javascript
+await get_job_status({ job_id });
+```
+
+**Inspect job configuration**:
+```javascript
+await get_manifest({ job_id });
+```
+
+**Review error timeline**:
+```javascript
+await get_events({ job_id });
+```
+
+**Check available devices**:
+```javascript
+await list_devices();
+```
+
+**Verify device capabilities**:
+```javascript
+await get_device_options({ device_id });
+```
+
+**List recent jobs**:
+```javascript
+await list_jobs({ limit: 10 });
+```
+
+**Filter by state**:
+```javascript
+await list_jobs({ state: "error" });
+```

--- a/.claude/skills/setup-mcp/ADVANCED.md
+++ b/.claude/skills/setup-mcp/ADVANCED.md
@@ -1,0 +1,209 @@
+# Advanced Configuration
+
+Advanced setup options for scan-mcp MCP server.
+
+## Contents
+
+- [Local Installation](#local-installation)
+- [Multiple MCP Server Configurations](#multiple-mcp-server-configurations)
+- [Backend Preferences](#backend-preferences)
+- [Mock Mode for Testing](#mock-mode-for-testing)
+- [Custom Binary Paths](#custom-binary-paths)
+- [Device Selection Control](#device-selection-control)
+
+---
+
+## Local Installation
+
+For development or testing unreleased features, use local installation instead of npx.
+
+### Prerequisites
+
+1. Clone scan-mcp repository
+2. Install dependencies and build:
+```bash
+cd /path/to/scan-mcp
+npm install
+npm run build
+```
+
+### Configuration
+
+**MCP config** (use absolute path):
+```json
+{
+  "mcpServers": {
+    "scan": {
+      "command": "node",
+      "args": ["/absolute/path/to/scan-mcp/build/index.js"],
+      "env": {
+        "INBOX_DIR": "~/Documents/scanned_documents/inbox"
+      }
+    }
+  }
+}
+```
+
+**Important**:
+- Replace `/absolute/path/to/scan-mcp` with actual repository path
+- Must run `npm run build` after code changes
+
+---
+
+## Multiple MCP Server Configurations
+
+Configure multiple scan-mcp instances with different settings:
+
+```json
+{
+  "mcpServers": {
+    "scan-personal": {
+      "command": "npx",
+      "args": ["-y", "scan-mcp"],
+      "env": {
+        "INBOX_DIR": "~/Documents/personal/scans"
+      }
+    },
+    "scan-work": {
+      "command": "npx",
+      "args": ["-y", "scan-mcp"],
+      "env": {
+        "INBOX_DIR": "~/Documents/work/scans",
+        "SCAN_PREFER_BACKENDS": "fujitsu"
+      }
+    }
+  }
+}
+```
+
+**Usage**: Specify which server to use in prompts: "Use scan-work to scan this"
+
+---
+
+## Backend Preferences
+
+Prefer specific SANE backends when multiple scanners are available:
+
+```json
+{
+  "mcpServers": {
+    "scan": {
+      "command": "npx",
+      "args": ["-y", "scan-mcp"],
+      "env": {
+        "INBOX_DIR": "~/Documents/scanned_documents/inbox",
+        "SCAN_PREFER_BACKENDS": "epson2,fujitsu",
+        "SCAN_EXCLUDE_BACKENDS": "v4l,test"
+      }
+    }
+  }
+}
+```
+
+**Environment variables**:
+- `SCAN_PREFER_BACKENDS`: Comma-separated list of backends to prefer (e.g., `epson2,fujitsu`)
+- `SCAN_EXCLUDE_BACKENDS`: Comma-separated list of backends to exclude (e.g., `v4l,test`)
+
+**Use cases**:
+- Exclude webcams/cameras (`v4l` backend)
+- Favor specific scanner brands
+- Skip test/mock devices
+
+---
+
+## Mock Mode for Testing
+
+Test scan-mcp without physical scanner:
+
+```json
+{
+  "mcpServers": {
+    "scan": {
+      "command": "npx",
+      "args": ["-y", "scan-mcp"],
+      "env": {
+        "INBOX_DIR": "~/Documents/scanned_documents/inbox",
+        "SCAN_MOCK": "true"
+      }
+    }
+  }
+}
+```
+
+Mock mode generates fake TIFF files for testing workflows without hardware.
+
+---
+
+## Custom Binary Paths
+
+Override scanner binary locations for custom SANE installations:
+
+```json
+{
+  "mcpServers": {
+    "scan": {
+      "command": "npx",
+      "args": ["-y", "scan-mcp"],
+      "env": {
+        "INBOX_DIR": "~/Documents/scanned_documents/inbox",
+        "SCANIMAGE_BIN": "/usr/local/bin/scanimage",
+        "SCANADF_BIN": "/usr/local/bin/scanadf",
+        "TIFFCP_BIN": "/opt/local/bin/tiffcp",
+        "IM_CONVERT_BIN": "/usr/local/bin/convert"
+      }
+    }
+  }
+}
+```
+
+**Available overrides**:
+- `SCANIMAGE_BIN` (default: `scanimage`)
+- `SCANADF_BIN` (default: `scanadf`)
+- `TIFFCP_BIN` (default: `tiffcp`)
+- `IM_CONVERT_BIN` (default: `convert`)
+
+---
+
+## Device Selection Control
+
+### Persistent Device Selection
+
+By default, scan-mcp lightly prefers the last-used scanner. Disable this:
+
+```json
+{
+  "mcpServers": {
+    "scan": {
+      "command": "npx",
+      "args": ["-y", "scan-mcp"],
+      "env": {
+        "INBOX_DIR": "~/Documents/scanned_documents/inbox",
+        "PERSIST_LAST_USED_DEVICE": "false"
+      }
+    }
+  }
+}
+```
+
+**When to use**: If you want truly neutral device selection each time.
+
+### Complete Example with All Options
+
+```json
+{
+  "mcpServers": {
+    "scan": {
+      "command": "npx",
+      "args": ["-y", "scan-mcp"],
+      "env": {
+        "INBOX_DIR": "~/Documents/scanned_documents/inbox",
+        "SCAN_PREFER_BACKENDS": "epson2,fujitsu",
+        "SCAN_EXCLUDE_BACKENDS": "v4l,test",
+        "PERSIST_LAST_USED_DEVICE": "true",
+        "SCANIMAGE_BIN": "/usr/local/bin/scanimage",
+        "TIFFCP_BIN": "/opt/local/bin/tiffcp"
+      }
+    }
+  }
+}
+```

--- a/.claude/skills/setup-mcp/PLATFORMS.md
+++ b/.claude/skills/setup-mcp/PLATFORMS.md
@@ -1,0 +1,158 @@
+# Platform-Specific Installation
+
+Prerequisites installation guide by platform.
+
+## Contents
+
+- [Debian/Ubuntu](#debianubuntu)
+- [Arch Linux](#arch-linux)
+- [Fedora/RHEL/CentOS](#fedorарhelcentos)
+- [macOS](#macos)
+- [Verifying Installation](#verifying-installation)
+
+---
+
+## Debian/Ubuntu
+
+### SANE Utilities
+
+```bash
+sudo apt-get update
+sudo apt-get install sane-utils
+```
+
+### TIFF Tools
+
+**Option 1: tiffcp (preferred)**
+```bash
+sudo apt-get install libtiff-tools
+```
+
+**Option 2: ImageMagick (fallback)**
+```bash
+sudo apt-get install imagemagick
+```
+
+### Scanner Permissions
+
+```bash
+# Add user to scanner group
+sudo usermod -a -G scanner $USER
+
+# Log out and log back in for changes to take effect
+```
+
+---
+
+## Arch Linux
+
+### SANE Utilities
+
+```bash
+sudo pacman -S sane
+```
+
+### TIFF Tools
+
+```bash
+sudo pacman -S libtiff
+```
+
+**Optional: ImageMagick**
+```bash
+sudo pacman -S imagemagick
+```
+
+### Scanner Permissions
+
+```bash
+sudo usermod -a -G scanner $USER
+```
+
+### Enable Scanner Service
+
+For network scanners:
+```bash
+sudo systemctl enable saned.socket
+sudo systemctl start saned.socket
+```
+
+---
+
+## Fedora/RHEL/CentOS
+
+### SANE Utilities
+
+```bash
+sudo dnf install sane-backends sane-backends-drivers-scanners
+```
+
+### TIFF Tools
+
+```bash
+sudo dnf install libtiff-tools
+```
+
+**Optional: ImageMagick**
+```bash
+sudo dnf install ImageMagick
+```
+
+### Scanner Permissions
+
+```bash
+sudo usermod -a -G scanner $USER
+```
+
+---
+
+## macOS
+
+### Using Homebrew
+
+**SANE Utilities**
+```bash
+brew install sane-backends
+```
+
+**TIFF Tools**
+```bash
+brew install libtiff
+```
+
+**Optional: ImageMagick**
+```bash
+brew install imagemagick
+```
+
+**Note**: macOS scanner support via SANE is limited. Native drivers may work better.
+
+---
+
+## Verifying Installation
+
+After installation on any platform, verify with scan-mcp preflight:
+
+```bash
+npx -y scan-mcp --preflight-only
+```
+
+**Expected output**:
+```
+✓ Node.js version check (22.x.x)
+✓ scanimage available (/usr/bin/scanimage)
+✓ TIFF tools available (tiffcp: /usr/bin/tiffcp)
+All preflight checks passed!
+```
+
+**Manual verification**:
+```bash
+# Check SANE
+scanimage --version
+
+# Check TIFF tools
+tiffcp -h
+
+# Or check ImageMagick
+convert --version
+```

--- a/.claude/skills/setup-mcp/SCANNERS.md
+++ b/.claude/skills/setup-mcp/SCANNERS.md
@@ -1,0 +1,189 @@
+# Scanner Setup Guide
+
+Device-specific scanner setup and permissions.
+
+## Contents
+
+- [USB Scanners](#usb-scanners)
+- [Network Scanners](#network-scanners)
+- [Multi-Function Printers](#multi-function-printers)
+- [Scanner Permissions](#scanner-permissions)
+
+---
+
+## USB Scanners
+
+### Auto-Detection
+
+Most USB scanners work automatically with SANE once drivers are installed.
+
+Test detection:
+```bash
+scanimage -L
+```
+
+### Permissions
+
+USB scanners require permission to access `/dev/bus/usb/` devices.
+
+**Check current groups**:
+```bash
+groups
+```
+
+Should include `scanner` or `lp`.
+
+**Add user to scanner group**:
+```bash
+sudo usermod -a -G scanner $USER
+# Log out and log back in
+```
+
+**For immediate effect** (without logout):
+```bash
+newgrp scanner
+```
+
+### Persistent Permissions with udev
+
+Create udev rule for your scanner:
+
+1. **Get vendor and product ID**:
+```bash
+lsusb | grep -i scanner
+# Example output: Bus 001 Device 003: ID 04b8:0158 Epson Corp.
+#                                      ^^^^ ^^^^
+#                                      vendor product
+```
+
+2. **Create udev rule**:
+```bash
+sudo nano /etc/udev/rules.d/99-scanner.rules
+```
+
+3. **Add line** (replace vendor/product IDs):
+```
+SUBSYSTEM=="usb", ATTR{idVendor}=="04b8", ATTR{idProduct}=="0158", MODE="0666"
+```
+
+4. **Reload udev rules**:
+```bash
+sudo udevadm control --reload-rules
+sudo udevadm trigger
+```
+
+---
+
+## Network Scanners
+
+### Configure SANE for Network Scanners
+
+1. **Identify scanner IP**:
+```bash
+# Find scanner on network
+nmap -p 1865,8610,8612 192.168.1.0/24
+```
+
+2. **Configure backend**:
+
+**For Epson network scanners** (`epsonds` backend):
+```bash
+sudo nano /etc/sane.d/epsonds.conf
+# Add line:
+net 192.168.1.100
+```
+
+**For HP network scanners** (`hpaio` backend):
+```bash
+sudo nano /etc/sane.d/hp.conf
+# Add line:
+ip=192.168.1.100
+```
+
+3. **Test detection**:
+```bash
+scanimage -L
+```
+
+---
+
+## Multi-Function Printers
+
+### HP MFPs
+
+Install HPLIP (HP Linux Imaging and Printing):
+
+**Debian/Ubuntu**:
+```bash
+sudo apt-get install hplip
+hp-setup
+```
+
+**Arch Linux**:
+```bash
+sudo pacman -S hplip
+hp-setup
+```
+
+**Fedora/RHEL**:
+```bash
+sudo dnf install hplip
+hp-setup
+```
+
+### Epson MFPs
+
+Usually work with `epson2` or `epsonds` backends (included in sane-backends).
+
+### Brother MFPs
+
+May require proprietary drivers from Brother website.
+
+### Canon MFPs
+
+Use `pixma` backend (included in sane-backends) or proprietary drivers.
+
+---
+
+## Scanner Permissions
+
+### Check Current Permissions
+
+```bash
+# Check USB device permissions
+ls -la /dev/bus/usb/*/*
+
+# Check user groups
+groups
+```
+
+### Common Permission Issues
+
+**"Permission denied" errors**:
+
+1. **Add to scanner group** (most common fix):
+```bash
+sudo usermod -a -G scanner $USER
+# Log out and log back in
+```
+
+2. **Check scanner group exists**:
+```bash
+grep scanner /etc/group
+```
+
+3. **For testing only** (not permanent):
+```bash
+# Run scanimage with sudo to verify permission issue
+sudo scanimage -L
+```
+
+### Verify Scanner Access
+
+```bash
+# Should list scanners without sudo
+scanimage -L
+
+# Test scan (doesn't actually scan)
+scanimage --test
+```

--- a/.claude/skills/setup-mcp/SKILL.md
+++ b/.claude/skills/setup-mcp/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: setup-mcp
+description: Configure scan-mcp MCP server in Claude Code's global configuration. Use when user wants to setup, configure, initialize, enable, or install the scan-mcp MCP server. Runs preflight checks for prerequisites (Node 22+, SANE tools, tiffcp), helps install missing dependencies, and adds server configuration with user-specified INBOX_DIR.
+---
+
+# scan-mcp MCP Server Setup
+
+Configure the scan-mcp MCP server in Claude Code's global configuration to enable scanner control.
+
+## Setup Workflow
+
+### Step 1: Gather User Preferences
+
+Ask user for:
+1. **INBOX_DIR location** (default: `~/Documents/scanned_documents/inbox`)
+2. **Installation method**: npx (recommended) or local
+
+### Step 2: Run Preflight Checks
+
+```bash
+npx -y scan-mcp --preflight-only
+```
+
+**Expected on success**: All checks passed!
+
+**If preflight fails**: Parse output to identify missing dependencies, then guide user through installation (see [PLATFORMS.md](PLATFORMS.md)).
+
+Common missing items:
+- SANE utilities (`scanimage`, `scanadf`)
+- TIFF tools (`tiffcp` or ImageMagick `convert`)
+
+### Step 3: Locate Claude Code MCP Configuration
+
+Claude Code config location:
+- `~/.config/claude/config.json` (Linux/macOS)
+- Create if doesn't exist
+
+### Step 4: Add or Update Configuration
+
+**Configuration structure (npx - recommended)**:
+```json
+{
+  "mcpServers": {
+    "scan": {
+      "command": "npx",
+      "args": ["-y", "scan-mcp"],
+      "env": {
+        "INBOX_DIR": "~/Documents/scanned_documents/inbox"
+      }
+    }
+  }
+}
+```
+
+**Important**:
+- If config.json doesn't exist: Create it with scan-mcp server entry
+- If config.json exists but no mcpServers: Add mcpServers section
+- If mcpServers exists: Add or update "scan" entry
+- Preserve existing MCP server configurations
+
+**For local installation** (advanced): See [ADVANCED.md](ADVANCED.md).
+
+### Step 5: Verify Configuration
+
+1. Inform user that Claude Code needs restart to pick up new configuration
+2. Suggest testing: `claude mcp` or asking "scan this document"
+3. If issues occur, suggest running `/doctor`
+
+## Quick Example
+
+**User**: "Setup scan-mcp"
+
+**Actions**:
+1. Ask: "Where would you like scanned documents stored? (Default: ~/Documents/scanned_documents/inbox)"
+2. Run: `npx -y scan-mcp --preflight-only`
+3. If preflight passes:
+   - Locate/create `~/.config/claude/config.json`
+   - Add scan-mcp server configuration
+   - Confirm: "scan-mcp configured. Please restart Claude Code. Test with 'scan this document'."
+4. If preflight fails:
+   - Identify missing dependencies
+   - Provide installation commands (see PLATFORMS.md)
+   - Re-run preflight after user installs
+
+## Reference Materials
+
+- **[PLATFORMS.md](PLATFORMS.md)** — Platform-specific prerequisite installation
+- **[SCANNERS.md](SCANNERS.md)** — Scanner permissions and device setup
+- **[TROUBLESHOOTING.md](TROUBLESHOOTING.md)** — Common setup issues and solutions
+- **[ADVANCED.md](ADVANCED.md)** — Local installation, multiple configs, advanced options

--- a/.claude/skills/setup-mcp/TROUBLESHOOTING.md
+++ b/.claude/skills/setup-mcp/TROUBLESHOOTING.md
@@ -1,0 +1,267 @@
+# Setup Troubleshooting
+
+Common issues when setting up scan-mcp MCP server.
+
+## Contents
+
+- [Configuration Issues](#configuration-issues)
+- [Preflight Failures](#preflight-failures)
+- [Scanner Detection Issues](#scanner-detection-issues)
+- [MCP Server Issues](#mcp-server-issues)
+- [Diagnostic Commands](#diagnostic-commands)
+
+---
+
+## Configuration Issues
+
+### "No MCP servers configured" After Setup
+
+**After adding scan-mcp to config.json:**
+
+**Causes**:
+1. Claude Code not restarted
+2. Config file in wrong location
+3. Invalid JSON syntax
+4. Permissions issue
+
+**Solutions**:
+
+1. **Verify file location and contents**:
+```bash
+cat ~/.config/claude/config.json
+```
+
+2. **Check JSON syntax**:
+```bash
+cat ~/.config/claude/config.json | jq .
+```
+
+3. **Verify permissions**:
+```bash
+ls -la ~/.config/claude/config.json
+# Should be readable by user
+```
+
+4. **Ensure restart**:
+- Fully exit Claude Code
+- Restart it
+- Run `/mcp` again
+
+### Config Changes Not Taking Effect
+
+**Symptoms**: Edited config.json, restarted Claude Code, changes not reflected.
+
+**Solutions**:
+
+1. **Verify you edited the correct file**:
+```bash
+find ~ -name "config.json" -path "*/claude/*" 2>/dev/null
+```
+
+2. **Check for JSON syntax errors**:
+```bash
+cat ~/.config/claude/config.json | jq .
+```
+
+3. **Ensure proper JSON structure**:
+- `mcpServers` must be an object
+- Server entries must have `command`, `args`
+- No trailing commas
+- Proper quotes around strings
+
+### Finding Config File
+
+**Check default location**:
+```bash
+ls -la ~/.config/claude/config.json
+```
+
+**Check XDG config**:
+```bash
+echo $XDG_CONFIG_HOME
+ls -la $XDG_CONFIG_HOME/claude/config.json
+```
+
+**Search for Claude config**:
+```bash
+find ~ -name "config.json" -path "*/claude/*" 2>/dev/null
+```
+
+---
+
+## Preflight Failures
+
+### "scanimage not found"
+
+**Issue**: Scanner backend not installed.
+
+**Solution**: Install SANE utilities (see [PLATFORMS.md](PLATFORMS.md)).
+
+### "No TIFF tools found"
+
+**Issue**: Neither tiffcp nor ImageMagick convert found.
+
+**Solution**: Install either libtiff-tools (preferred) or ImageMagick:
+
+**Debian/Ubuntu**:
+```bash
+sudo apt-get install libtiff-tools
+# Or
+sudo apt-get install imagemagick
+```
+
+See [PLATFORMS.md](PLATFORMS.md) for other platforms.
+
+### "Node.js version too low"
+
+**Issue**: scan-mcp requires Node.js 22+.
+
+**Solution**: Claude Code already requires Node 22+, but verify:
+```bash
+node --version
+```
+
+---
+
+## Scanner Detection Issues
+
+### "scanimage -L" Shows No Devices
+
+**Causes**:
+1. Scanner not powered on or connected
+2. User lacks permissions
+3. SANE can't see the scanner
+4. Wrong backend needed
+
+**Solutions**:
+
+1. **Check physical connection**:
+- Ensure scanner is powered on
+- USB cable properly connected
+- For network scanners, verify network connectivity
+
+2. **Check permissions**:
+```bash
+# Check current groups
+groups
+# Should include 'scanner' or 'lp'
+
+# If not, add user to scanner group:
+sudo usermod -a -G scanner $USER
+# Log out and log back in
+```
+
+3. **Test USB device visibility**:
+```bash
+lsusb | grep -i scanner
+# Or more generically
+lsusb
+```
+
+4. **Check SANE backends**:
+```bash
+# List available backends
+scanimage -L
+
+# Force specific backend (if known)
+scanimage -L --device-name=epson2:libusb:001:003
+```
+
+5. **Enable backend explicitly**:
+
+Edit `/etc/sane.d/dll.conf` and uncomment your scanner's backend:
+```bash
+sudo nano /etc/sane.d/dll.conf
+# Uncomment line for your scanner (e.g., 'epson2', 'fujitsu', 'hpaio')
+```
+
+See [SCANNERS.md](SCANNERS.md) for more scanner-specific setup.
+
+---
+
+## MCP Server Issues
+
+### MCP Server Starts But Tools Don't Work
+
+**Symptoms**:
+- `/mcp` shows scan server
+- But `list_devices` or `start_scan_job` fails
+
+**Causes**:
+1. INBOX_DIR not writable
+2. Scanner permissions issue
+3. Missing dependencies
+
+**Solutions**:
+
+1. **Verify INBOX_DIR**:
+```bash
+# Check if directory exists and is writable
+ls -la ~/Documents/scanned_documents/
+
+# Create if needed
+mkdir -p ~/Documents/scanned_documents/inbox
+
+# Test write permission
+touch ~/Documents/scanned_documents/inbox/test.txt
+rm ~/Documents/scanned_documents/inbox/test.txt
+```
+
+2. **Check scanner access manually**:
+```bash
+scanimage -L
+# Should list devices
+
+# Try test scan
+scanimage --test
+```
+
+3. **Review MCP server logs**: Claude Code may log MCP server errors.
+
+---
+
+## Diagnostic Commands
+
+**Check SANE installation**:
+```bash
+scanimage --version
+scanimage -L
+```
+
+**Check TIFF tools**:
+```bash
+tiffcp -h
+convert --version
+```
+
+**Check Node.js version**:
+```bash
+node --version
+```
+
+**Run scan-mcp preflight**:
+```bash
+npx -y scan-mcp --preflight-only
+```
+
+**Verify Claude Code MCP config**:
+```bash
+cat ~/.config/claude/config.json | jq .
+```
+
+**List MCP servers** (from within Claude Code):
+```
+/mcp
+```
+
+**Test scanner manually**:
+```bash
+# List devices
+scanimage -L
+
+# Test scan (doesn't actually scan)
+scanimage --test
+
+# Quick actual scan (if device known)
+scanimage -d 'device_id_here' --format=tiff > test.tiff
+```


### PR DESCRIPTION
Add two skills following Claude Code best practices:

- scan: Guides Claude to use scan-mcp MCP server effectively
  - Emphasizes THE GOLDEN RULE: trust server defaults
  - Progressive disclosure with TOOLS, EXAMPLES, TROUBLESHOOTING, CONFIG
  - Concise SKILL.md (70 lines) with topic-organized references

- setup-mcp: Configures scan-mcp in Claude Code's global MCP config
  - 5-step setup workflow with preflight checks
  - Progressive disclosure: PLATFORMS, SCANNERS, TROUBLESHOOTING, ADVANCED
  - Platform-specific installation guides

Both skills use progressive disclosure pattern with concise main files
and detailed references organized by topic, following best practices
for token efficiency and discoverability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
