### PR TITLE
fix: populate empty LICENSE file with standard MIT text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Jack Senechal
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

The repository's `LICENSE` file is currently empty (0 bytes). It was added in #14 ("Add license and lobehub badge") but committed without content.

`package.json` declares `"license": "MIT"`, npm publishes the package as MIT, and the PR title makes the intent clear — but the canonical license text isn't actually present in the source tree. This is a small but worth-fixing gap, since downstream consumers (forks, redistributors, license scanners like FOSSA / GitHub's license detection) rely on the LICENSE file content rather than just the `package.json` field.

This PR populates `LICENSE` with the standard MIT text and your copyright (year derived from the first commit, August 2025). No other changes.

## Test plan

- [x] `LICENSE` is now non-empty and contains the canonical MIT text
- [x] Copyright line matches existing intent (`package.json: "license": "MIT"`)
- [ ] GitHub's repo sidebar will now show "MIT license" instead of a "License" placeholder
- [ ] License scanners (FOSSA, GitHub Linguist) will detect MIT correctly

Happy to adjust the copyright line if you'd prefer a different format (e.g., year range, "Jack Senechal and contributors", etc.).

---

For context: I'm working on adding a macOS/ImageCaptureCore backend to scan-mcp in a fork. Filing this license fix first as a small, independent contribution before sending anything larger your way. 🙂

🤖 Generated with [Claude Code](https://claude.com/claude-code)