### PR TITLE
fix: map generic sources to device-reported names and expand ~ in INBOX_DIR

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { ZodIssue } from "zod";
 import dotenv from "dotenv";
+import os from "os";
 
 export const ConfigSchema = z.object({
   LOG_LEVEL: z.string().default("info"),
@@ -40,7 +41,18 @@ export function loadConfig(): AppConfig {
         parsed.error.issues.map((e: ZodIssue) => `${e.path.join(".")}: ${e.message}`).join("; ")
     );
   }
-  return parsed.data;
+  return { ...parsed.data, INBOX_DIR: expandTilde(parsed.data.INBOX_DIR) };
+}
+
+/**
+ * Expand a leading `~` (referring to the current user's home directory) at the start
+ * of a path, e.g. "~/Documents/inbox" -> "/home/user/Documents/inbox" and "~" alone ->
+ * "/home/user". Paths not starting with `~` are returned unchanged.
+ */
+export function expandTilde(p: string): string {
+  if (p === "~") return os.homedir();
+  if (p.startsWith("~/") || p.startsWith("~\\")) return p.replace(/^~/, os.homedir());
+  return p;
 }
 
 function parseEnvBool(v: string | undefined): boolean | undefined {

--- a/src/services/jobs.ts
+++ b/src/services/jobs.ts
@@ -18,7 +18,10 @@ export type StartScanInput = {
   resolution_dpi?: number;
   // SANE backends vary (e.g., Halftone, Binary, Gray16); accept any string
   color_mode?: string;
-  source?: "Flatbed" | "ADF" | "ADF Duplex";
+  // The MCP tool schema restricts requests to "Flatbed" | "ADF" | "ADF Duplex", but the
+  // effective/resolved value may be a device-specific string (e.g. "ADF Front") once
+  // mapped against the device's reported sources, so this is widened to `string`.
+  source?: string;
   duplex?: boolean;
   page_size?: "Letter" | "A4" | "Legal" | "Custom";
   custom_size_mm?: { width: number; height: number };
@@ -353,6 +356,45 @@ function buildCommonArgs(input: StartScanInput, batchPattern: string): string[] 
   return args;
 }
 
+/**
+ * Map a requested generic source ("Flatbed" | "ADF" | "ADF Duplex") to the closest
+ * matching source string actually reported by the device (e.g. a Fujitsu ScanSnap
+ * reports ["ADF Front", "ADF Back", "ADF Duplex"], with no plain "ADF" or "Flatbed").
+ *
+ * Resolution order:
+ *  - exact (case-sensitive) match against the device's reported sources
+ *  - for "ADF": "ADF Front", else any source containing "ADF" (non-duplex preferred)
+ *  - for "ADF Duplex": any source containing "Duplex"
+ *  - for "Flatbed": any source containing "Flatbed"
+ *  - otherwise: any source containing the requested string
+ * Throws a clear error listing the device's supported sources if nothing matches.
+ */
+export function resolveSourceForDevice(requested: string, available: string[]): string {
+  if (available.includes(requested)) return requested;
+
+  const containing = (word: string, exclude?: string): string | undefined =>
+    available.find(
+      (s) => s.toLowerCase().includes(word.toLowerCase()) && (!exclude || !s.toLowerCase().includes(exclude.toLowerCase()))
+    );
+
+  const fail = (): never => {
+    throw new Error(
+      `Requested source "${requested}" is not supported by this device. Supported sources: ${available.join(", ")}`
+    );
+  };
+
+  if (requested === "ADF") {
+    return available.find((s) => s === "ADF Front") ?? containing("ADF", "Duplex") ?? containing("ADF") ?? fail();
+  }
+  if (requested === "ADF Duplex") {
+    return containing("Duplex") ?? fail();
+  }
+  if (requested === "Flatbed") {
+    return containing("Flatbed") ?? fail();
+  }
+  return containing(requested) ?? fail();
+}
+
 export function segmentPages(pages: number[], policy?: StartScanInput["doc_break_policy"]): number[][] {
   if (!policy || !policy.type || policy.type === "none" || !policy.page_count) {
     return [pages];
@@ -398,19 +440,29 @@ export async function resolveEffectiveInput(input: StartScanInput, ctx: AppConte
   }
 
   if (out.device_id) {
+    let opts: Awaited<ReturnType<typeof getDeviceOptions>> | undefined;
     try {
-      const opts = await getDeviceOptions(out.device_id, ctx);
-      if (!out.source && opts.sources && opts.sources.length) {
-        const selected = opts.sources.includes("ADF Duplex")
-          ? "ADF Duplex"
-          : opts.sources.includes("ADF")
-            ? "ADF"
-            : opts.sources[0];
-        out.source = selected as StartScanInput["source"];
-      }
-      // If duplex requested, prefer ADF Duplex when available
-      if (out.duplex && opts.sources && opts.sources.includes("ADF Duplex")) {
-        out.source = "ADF Duplex";
+      opts = await getDeviceOptions(out.device_id, ctx);
+    } catch {
+      // If the provided device_id cannot be probed, drop it and fall back to selection
+      out.device_id = undefined;
+    }
+    if (opts) {
+      if (opts.sources && opts.sources.length) {
+        // If duplex requested, prefer ADF Duplex regardless of any source already set.
+        const requested = out.duplex ? "ADF Duplex" : out.source;
+        if (requested) {
+          // Let a mapping failure (device doesn't support the requested source) propagate
+          // as a clear error rather than silently falling back to device deselection.
+          out.source = resolveSourceForDevice(requested, opts.sources);
+        } else {
+          const selected = opts.sources.includes("ADF Duplex")
+            ? "ADF Duplex"
+            : opts.sources.includes("ADF")
+              ? "ADF"
+              : opts.sources[0];
+          out.source = selected;
+        }
       }
       if (!out.resolution_dpi) {
         // First, probe 300dpi explicitly; many devices support it even if not listed
@@ -446,9 +498,6 @@ export async function resolveEffectiveInput(input: StartScanInput, ctx: AppConte
           out.color_mode = selected;
         }
       }
-    } catch {
-      // If the provided device_id cannot be probed, drop it and fall back to selection
-      out.device_id = undefined;
     }
   }
 

--- a/src/services/select.ts
+++ b/src/services/select.ts
@@ -2,7 +2,7 @@ import type { AppContext } from "../context.js";
 import { listDevices, getDeviceOptions, type DeviceOptions } from "./sane.js";
 
 export type SelectionInput = {
-  desiredSource?: "Flatbed" | "ADF" | "ADF Duplex";
+  desiredSource?: string;
   desiredResolutionDpi?: number;
 };
 

--- a/src/tests/config.test.ts
+++ b/src/tests/config.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { loadConfig } from "../config.js";
+import os from "os";
+import path from "path";
+import { loadConfig, expandTilde } from "../config.js";
 
 const ENV_VARS = [
   "LOG_LEVEL",
@@ -63,6 +65,39 @@ describe("loadConfig", () => {
     expect(cfg.IM_CONVERT_BIN).toBe("convert2");
     expect(cfg.SCAN_EXCLUDE_BACKENDS).toEqual(["v4l", "net"]);
     expect(cfg.SCAN_PREFER_BACKENDS).toEqual(["fujitsu", "canon"]);
+  });
+
+  it("expands a leading ~ in INBOX_DIR to the home directory", () => {
+    process.env.INBOX_DIR = "~/Documents/scanned_documents/inbox";
+    const cfg = loadConfig();
+    expect(cfg.INBOX_DIR).toBe(path.join(os.homedir(), "Documents/scanned_documents/inbox"));
+  });
+
+  it("expands a bare ~ to the home directory", () => {
+    process.env.INBOX_DIR = "~";
+    const cfg = loadConfig();
+    expect(cfg.INBOX_DIR).toBe(os.homedir());
+  });
+
+  it("leaves absolute and relative paths without a leading ~ unchanged", () => {
+    process.env.INBOX_DIR = "/tmp/inbox";
+    expect(loadConfig().INBOX_DIR).toBe("/tmp/inbox");
+
+    process.env.INBOX_DIR = "scanned_documents/inbox";
+    expect(loadConfig().INBOX_DIR).toBe("scanned_documents/inbox");
+  });
+});
+
+describe("expandTilde", () => {
+  it("expands ~ and ~/ prefixes", () => {
+    expect(expandTilde("~")).toBe(os.homedir());
+    expect(expandTilde("~/foo/bar")).toBe(path.join(os.homedir(), "foo/bar"));
+  });
+
+  it("does not touch paths without a leading ~", () => {
+    expect(expandTilde("/foo/~/bar")).toBe("/foo/~/bar");
+    expect(expandTilde("foo/bar")).toBe("foo/bar");
+    expect(expandTilde("~user/bar")).toBe("~user/bar");
   });
 });
 

--- a/src/tests/jobs_plan.spec.ts
+++ b/src/tests/jobs_plan.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import path from "path";
-import { planScanCommands, segmentPages } from "../services/jobs.js";
+import { planScanCommands, segmentPages, resolveSourceForDevice } from "../services/jobs.js";
 import type { AppConfig } from "../config.js";
 import type { AppContext } from "../context.js";
 import type { Logger } from "pino";
@@ -40,6 +40,44 @@ describe("command planning", () => {
     expect(letter).toMatch(/-x 215\.9mm -y 279\.4mm/);
     const a4 = planScanCommands({ device_id: "dev", page_size: "A4" }, runDir, ctx)[0].args.join(" ");
     expect(a4).toMatch(/-x 210mm -y 297mm/);
+  });
+});
+
+describe("resolveSourceForDevice", () => {
+  // Fujitsu ScanSnap S1500-style device: reports no plain "ADF" or "Flatbed".
+  const scansnap = ["ADF Front", "ADF Back", "ADF Duplex"];
+
+  it("maps generic ADF to ADF Front when device has no plain ADF source", () => {
+    expect(resolveSourceForDevice("ADF", scansnap)).toBe("ADF Front");
+  });
+
+  it("maps generic ADF Duplex to the device's Duplex source", () => {
+    expect(resolveSourceForDevice("ADF Duplex", scansnap)).toBe("ADF Duplex");
+  });
+
+  it("prefers an exact match when available", () => {
+    const sources = ["Flatbed", "ADF", "ADF Duplex"];
+    expect(resolveSourceForDevice("ADF", sources)).toBe("ADF");
+    expect(resolveSourceForDevice("ADF Duplex", sources)).toBe("ADF Duplex");
+    expect(resolveSourceForDevice("Flatbed", sources)).toBe("Flatbed");
+  });
+
+  it("prefers a non-duplex ADF source over a duplex one when mapping generic ADF", () => {
+    expect(resolveSourceForDevice("ADF", ["ADF Duplex", "ADF Simplex"])).toBe("ADF Simplex");
+  });
+
+  it("falls back to any ADF-containing source if nothing else matches", () => {
+    expect(resolveSourceForDevice("ADF", ["ADF Duplex"])).toBe("ADF Duplex");
+  });
+
+  it("maps Flatbed to a source containing Flatbed", () => {
+    expect(resolveSourceForDevice("Flatbed", ["Document Table (Flatbed)", "ADF Front"])).toBe("Document Table (Flatbed)");
+  });
+
+  it("throws a clear error listing supported sources when nothing matches", () => {
+    expect(() => resolveSourceForDevice("Flatbed", scansnap)).toThrow(
+      /Flatbed.*not supported.*ADF Front, ADF Back, ADF Duplex/s
+    );
   });
 });
 

--- a/src/tests/resolve_effective.spec.ts
+++ b/src/tests/resolve_effective.spec.ts
@@ -34,6 +34,34 @@ describe("resolveEffectiveInput", () => {
     expect(eff.source).toBe("ADF Duplex");
   });
 
+  it("maps a requested generic ADF source to the device's reported source (Fujitsu ScanSnap S1500)", async () => {
+    vi.spyOn(sane, "getDeviceOptions").mockResolvedValue({
+      sources: ["ADF Front", "ADF Back", "ADF Duplex"],
+      resolutions: [300],
+    });
+    const eff = await resolveEffectiveInput({ device_id: "dev", source: "ADF" }, ctx);
+    expect(eff.source).toBe("ADF Front");
+  });
+
+  it("maps a requested ADF Duplex source to the device's Duplex source", async () => {
+    vi.spyOn(sane, "getDeviceOptions").mockResolvedValue({
+      sources: ["ADF Front", "ADF Back", "ADF Duplex"],
+      resolutions: [300],
+    });
+    const eff = await resolveEffectiveInput({ device_id: "dev", source: "ADF Duplex" }, ctx);
+    expect(eff.source).toBe("ADF Duplex");
+  });
+
+  it("rejects an unsupported requested source with a clear error instead of running scanimage", async () => {
+    vi.spyOn(sane, "getDeviceOptions").mockResolvedValue({
+      sources: ["ADF Front", "ADF Back", "ADF Duplex"],
+      resolutions: [300],
+    });
+    await expect(resolveEffectiveInput({ device_id: "dev", source: "Flatbed" }, ctx)).rejects.toThrow(
+      /Flatbed.*not supported/
+    );
+  });
+
   it("picks 300dpi when available", async () => {
     vi.spyOn(sane, "getDeviceOptions").mockResolvedValue({ resolutions: [200, 300, 600] });
     const eff = await resolveEffectiveInput({ device_id: "dev" }, ctx);


### PR DESCRIPTION
## Summary
Two bugs found while scanning with a Fujitsu ScanSnap S1500:

1. **Source mapping**: the tool schema offers `"ADF"`, but the S1500 only reports `"ADF Front"`, `"ADF Back"`, `"ADF Duplex"`, so `scanimage --source ADF` failed with "Invalid argument". `resolveSourceForDevice()` now maps the generic request to the closest device-reported source (exact match, then non-duplex ADF variants, then substring), and fails with an error listing the device's supported sources when nothing matches. A mapping failure no longer silently drops the user's `device_id`; only a failed device probe does.

2. **Tilde expansion**: with `INBOX_DIR=~/Documents/scanned_documents/inbox`, run dirs were created under a literal `~/` directory relative to cwd. A leading `~` is now expanded to the home directory at config load.

## Test plan
- New unit tests for `resolveSourceForDevice` (ScanSnap-style mapping, non-duplex preference, error case) and `expandTilde`
- New `resolveEffectiveInput` tests for mapping and rejection paths
- `npm run typecheck`, `npm run lint`, `npm run test:run`: 62/62 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kAMZt9SC16oouAgE2jTJE