### PR TITLE
feat: support MCP_HTTP_HOST to restrict HTTP transport bind address

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ scan-mcp --http
 ```
 
 - Default port is `3001`; set `MCP_HTTP_PORT` to override (for example `MCP_HTTP_PORT=3333 scan-mcp --http`).
+- Binds all interfaces (`::`) by default; set `MCP_HTTP_HOST` to restrict (for example `MCP_HTTP_HOST=127.0.0.1` when a reverse proxy fronts the server).
 - HTTP responses use server-sent events (SSE) for streaming tool output; clients such as Claude Desktop and Windsurf support
   this transport.
 - There is currently no authentication; this is intended for internal LAN networking

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -80,8 +80,9 @@ export function startHttpServer(opts: { enableStreamable?: boolean } = {}): Http
   }
 
   const port = Number(process.env.MCP_HTTP_PORT || 3001);
-  const server = app.listen(port, "::", () => {
-    logger.info({ port, enableStreamable }, "scan-mcp HTTP server ready");
+  const host = process.env.MCP_HTTP_HOST || "::";
+  const server = app.listen(port, host, () => {
+    logger.info({ port, host, enableStreamable }, "scan-mcp HTTP server ready");
   });
   return server;
 }


### PR DESCRIPTION
Deployed and verified on homebox (systemd unit sets MCP_HTTP_HOST=127.0.0.1 behind Caddy). Default bind unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kAMZt9SC16oouAgE2jTJE