### PR TITLE
ci: fix release pipeline so npm publish runs automatically

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,15 +8,34 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - name: Release Please
+        id: release
         uses: googleapis/release-please-action@v4
         with:
+          # NOTE: do not add a release-type input here; it would switch the action
+          # to bootstrap mode and silently ignore this config file (extra-files etc.)
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          release-type: node
           target-branch: main
+
+  # Releases created above use GITHUB_TOKEN, whose events never trigger other
+  # workflows, so the Release workflow must be dispatched explicitly
+  # (workflow_dispatch is exempt from that restriction).
+  trigger-publish:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch Release workflow for the new tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run release.yml --repo ${{ github.repository }} --ref ${{ needs.release-please.outputs.tag_name }}

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/jacksenechal/scan-mcp",
     "source": "github"
   },
-  "version": "0.2.0",
+  "version": "0.3.0",
   "packages": [
     {
       "registry_type": "npm",
       "registry_base_url": "https://registry.npmjs.org",
       "identifier": "scan-mcp",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
See commit message. After merge, 0.3.0 still needs one manual dispatch of the Release workflow (the fix applies to future releases); this session handles that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kAMZt9SC16oouAgE2jTJE