### PR TITLE
ci: bump mcp-publisher to v1.8.0 for new registry OIDC audience

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
           npm publish --provenance --access public
       - name: Install MCP Publisher CLI
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.0.0/mcp-publisher_1.0.0_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.8.0/mcp-publisher_1.8.0_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
             | tar xz mcp-publisher
       - name: Login to MCP Registry (GitHub OIDC)
         run: ./mcp-publisher login github-oidc


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kAMZt9SC16oouAgE2jTJE