### PR TITLE
feat: detect carrier sheets and optionally crop page derivatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Add a server entry to your MCP client configuration:
 
 - This invocation runs over stdio for a privacy-first, single-machine setup.
 - Call `start_scan_job` without a `device_id` to auto-select a scanner and begin scanning.
-- Artifacts are written under `INBOX_DIR` per job: `job-*/page_*.tiff`, `doc_*.tiff`, `manifest.json`, `events.jsonl`.
+- Artifacts are written under `INBOX_DIR` per job: `job-*/page_*.tiff`, `doc_*.tiff`, `manifest.json`, `events.jsonl`. When `crop_carrier_sheets` is set and a carrier sheet is detected, a `page_*.cropped.tiff` derivative is also written per affected page.
 
 ## Streamable HTTP transport
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ scan-mcp --http
     - `doc_break_policy` { `type`, `blank_threshold`, `page_count`, `timer_ms`, `barcode_values` }
     - `output_format` (string, default `tiff`)
     - `tmp_dir` (string)
+    - `crop_carrier_sheets` (boolean, default `false`): detect carrier-sheet leading-edge band and write cropped page derivatives; raw pages are kept
 
 - **get_job_status**
   - Inspect job state and artifact counts.

--- a/resources/ORIENTATION.md
+++ b/resources/ORIENTATION.md
@@ -37,6 +37,10 @@ Inputs for `start_scan_job` (all optional unless specified):
 - `page_size`: `Letter` | `A4` | `Legal` | `Custom` (+ `custom_size_mm`).
 - `doc_break_policy`: Advanced per-page splitting config (optional).
 - `tmp_dir`: Override base dir for `run_dir` placement (optional).
+- `crop_carrier_sheets`: If `true`, crop pages that show a detected carrier-sheet leading-edge band and assemble documents from the cropped derivatives (optional; default `false`).
+
+## Carrier Sheets
+Scanner carrier sheets (clear sleeves for fragile/small documents) leave a dark leading-edge pattern band across the top of the raw scan. The server always detects this band and annotates the affected page in the manifest (`carrier_sheet: { detected: true, band_rows }`); nothing changes in the captured files unless you opt in. Pass `crop_carrier_sheets: true` to also write a cropped derivative next to each affected raw page (`cropped_path`, `cropped_sha256`); the raw page is never modified or deleted, and assembled documents use the cropped derivative when present.
 
 ## Mapping User Requests To Parameters
 

--- a/resources/ORIENTATION.md
+++ b/resources/ORIENTATION.md
@@ -76,11 +76,11 @@ After `start_scan_job`, you receive `{ job_id, run_dir, state }`.
 - Poll `get_job_status { job_id }` until `state` is `completed`.
 - In `run_dir`, you should see:
   - `manifest.json`: job metadata, params, page and document listings.
-  - `events.jsonl`: chronological events (e.g., `job_started`, `scanner_exec`, `job_completed`).
+  - `events.jsonl`: chronological events (e.g., `job_started`, `scanner_exec`, `carrier_sheet_detected`, `carrier_sheet_cropped`, `carrier_detection_skipped`, `job_completed`).
   - `page_0001.tiff`, `page_0002.tiff`, …: raw captured pages.
   - `doc_0001.tiff` (and/or assembled outputs when configured): multipage artifacts.
 - A typical events sequence includes:
-  - `job_started` → `scanner_exec` → (optional `scanner_failed` on retries) → `job_completed`.
+  - `job_started` → `scanner_exec` → (optional `scanner_failed` on retries) → (optional `carrier_sheet_detected` / `carrier_sheet_cropped` per page, or `carrier_detection_skipped` if ImageMagick is unavailable) → `job_completed`.
 
 ## Troubleshooting Flow (When Something Goes Wrong)
 1) Inspect manifest and events:

--- a/schemas/start_scan_job.schema.json
+++ b/schemas/start_scan_job.schema.json
@@ -32,6 +32,11 @@
       }
     },
     "output_format": { "type": "string", "default": "tiff" },
-    "tmp_dir": { "type": "string" }
+    "tmp_dir": { "type": "string" },
+    "crop_carrier_sheets": {
+      "type": "boolean",
+      "default": false,
+      "description": "Detect carrier-sheet leading-edge band and write cropped page derivatives; raw pages are kept."
+    }
   }
 }

--- a/src/server/register.ts
+++ b/src/server/register.ts
@@ -55,6 +55,8 @@ export function registerScanServer(server: McpServer, ctx: AppContext) {
     ),
     output_format: nullToUndef(z.string()),
     tmp_dir: nullToUndef(z.string()),
+    // Detect carrier sheet leading-edge band and crop derivatives.
+    crop_carrier_sheets: nullToUndef(z.boolean()),
   });
 
   server.tool(

--- a/src/services/carrier.ts
+++ b/src/services/carrier.ts
@@ -1,0 +1,289 @@
+import { execa } from "execa";
+import type { AppContext } from "../context.js";
+
+/** Number of row samples the row-mean gray profile is downsampled to. */
+export const PROFILE_SAMPLES = 256;
+
+export type Box = { x: number; y: number; w: number; h: number };
+
+export type ConnectedComponent = { x: number; y: number; w: number; h: number; area: number; color: string };
+
+// ---------------------------------------------------------------------------
+// Pure functions (no I/O)
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse ImageMagick `txt:-` output of a 1xN grayscale image into an array of
+ * N luminance means normalized to 0..1, ordered by row.
+ */
+export function parseGrayProfile(txt: string): number[] {
+  const rows: { y: number; value: number }[] = [];
+  const lineRe = /^\s*(\d+),(\d+):\s*\([^)]*\)\s*#[0-9A-Fa-f]+\s*(.+?)\s*$/;
+  for (const line of txt.split(/\r?\n/)) {
+    if (!line || line.startsWith("#")) continue;
+    const m = lineRe.exec(line);
+    if (!m) continue;
+    const y = parseInt(m[2], 10);
+    const value = colorSpecToUnit(m[3]);
+    if (value === null) continue;
+    rows.push({ y, value });
+  }
+  rows.sort((a, b) => a.y - b.y);
+  return rows.map((r) => r.value);
+}
+
+/** Parse a trailing color spec (`gray(NNN)`, `gray(NN%)`, `srgb(r,g,b)`) into a 0..1 unit value. */
+function colorSpecToUnit(spec: string): number | null {
+  let m = /gray\((\d+(?:\.\d+)?)%\)/i.exec(spec);
+  if (m) return parseFloat(m[1]) / 100;
+
+  m = /gray\((\d+(?:\.\d+)?)\)/i.exec(spec);
+  if (m) return parseFloat(m[1]) / 255;
+
+  m = /srgb\(\s*(\d+(?:\.\d+)?)\s*,\s*(\d+(?:\.\d+)?)\s*,\s*(\d+(?:\.\d+)?)\s*\)/i.exec(spec);
+  if (m) {
+    const avg = (parseFloat(m[1]) + parseFloat(m[2]) + parseFloat(m[3])) / 3;
+    return avg / 255;
+  }
+
+  return null;
+}
+
+export type DetectBandOptions = {
+  darkThreshold?: number;
+  maxStartFrac?: number;
+  minThicknessSamples?: number;
+  maxThicknessFrac?: number;
+  maxGapSamples?: number;
+};
+
+/**
+ * Find the carrier band as the first contiguous run of "dark" samples. The
+ * leading-edge pattern always sits within the top few percent of the page
+ * (the sheet is fed pattern-first), so only the very first dark run is
+ * considered; if it doesn't qualify, there is no carrier band.
+ */
+export function detectBandFromRowMeans(
+  means: number[],
+  opts: DetectBandOptions = {}
+): { start: number; end: number } | null {
+  const { darkThreshold = 0.55, maxStartFrac = 0.08, minThicknessSamples = 2, maxThicknessFrac = 0.12, maxGapSamples = 4 } = opts;
+  const n = means.length;
+  if (n === 0) return null;
+
+  let start = -1;
+  for (let i = 0; i < n; i++) {
+    if (means[i] < darkThreshold) {
+      start = i;
+      break;
+    }
+  }
+  if (start === -1) return null;
+
+  let end = start;
+  while (end + 1 < n && means[end + 1] < darkThreshold) end++;
+
+  // Merge subsequent dark runs separated by short light gaps: patterns like the
+  // Fujitsu filmstrip have a row of white sprocket squares inside the band, which
+  // splits it into two dark runs in the profile.
+  for (;;) {
+    let next = end + 1;
+    while (next < n && means[next] >= darkThreshold) next++;
+    if (next >= n || next - end - 1 > maxGapSamples || next - start + 1 > maxThicknessFrac * n) break;
+    end = next;
+    while (end + 1 < n && means[end + 1] < darkThreshold) end++;
+  }
+
+  const length = end - start + 1;
+  const maxStart = maxStartFrac * n;
+  const maxThickness = maxThicknessFrac * n;
+  if (start <= maxStart && length >= minThicknessSamples && length <= maxThickness) {
+    return { start, end };
+  }
+  return null;
+}
+
+/** Convert a band in sample-index space to inclusive pixel rows in an imageHeight-tall image. */
+export function bandSamplesToRows(band: { start: number; end: number }, samples: number, imageHeight: number): [number, number] {
+  const startRow = Math.floor((band.start / samples) * imageHeight);
+  const endRow = Math.min(imageHeight - 1, Math.ceil(((band.end + 1) / samples) * imageHeight));
+  return [startRow, endRow];
+}
+
+/**
+ * Parse `-define connected-components:verbose=true` output lines, e.g.:
+ * `  2: 313x412+44+0 200.0,270.9 128561 gray(255)`
+ * (format: `id: WxH+X+Y centroidX,centroidY area color`).
+ */
+export function parseConnectedComponents(verbose: string): ConnectedComponent[] {
+  const out: ConnectedComponent[] = [];
+  const lineRe = /^\s*\d+:\s+(\d+)x(\d+)\+(\d+)\+(\d+)\s+[\d.\-]+,[\d.\-]+\s+(\d+)\s+(.+?)\s*$/;
+  for (const line of verbose.split(/\r?\n/)) {
+    if (!line || /^\s*Objects\s*\(/.test(line)) continue;
+    const m = lineRe.exec(line);
+    if (!m) continue;
+    out.push({
+      w: parseInt(m[1], 10),
+      h: parseInt(m[2], 10),
+      x: parseInt(m[3], 10),
+      y: parseInt(m[4], 10),
+      area: parseInt(m[5], 10),
+      color: m[6],
+    });
+  }
+  return out;
+}
+
+/**
+ * Among components whose color is "light" (gray/srgb value >= 200/255), pick the
+ * largest by area. Returns null if none qualify, or if the winner is too small
+ * (< 2% of the image area) to plausibly be the document.
+ */
+export function pickDocumentComponent(components: ConnectedComponent[], imgW: number, imgH: number): Box | null {
+  const light = components.filter((c) => {
+    const unit = colorSpecToUnit(c.color);
+    return unit !== null && unit * 255 >= 200;
+  });
+  if (light.length === 0) return null;
+
+  const winner = light.reduce((best, c) => (c.area > best.area ? c : best), light[0]);
+  const minArea = 0.02 * imgW * imgH;
+  if (winner.area < minArea) return null;
+
+  return { x: winner.x, y: winner.y, w: winner.w, h: winner.h };
+}
+
+/** Add marginFrac of the larger image dimension on each side; clamp to the image bounds. */
+export function expandAndClampBox(box: Box, imgW: number, imgH: number, marginFrac = 0.01, minY = 0): Box {
+  const margin = marginFrac * Math.max(imgW, imgH);
+  const x0 = clamp(box.x - margin, 0, imgW);
+  const y0 = clamp(box.y - margin, minY, imgH);
+  const x1 = clamp(box.x + box.w + margin, 0, imgW);
+  const y1 = clamp(box.y + box.h + margin, minY, imgH);
+  return { x: Math.round(x0), y: Math.round(y0), w: Math.round(x1 - x0), h: Math.round(y1 - y0) };
+}
+
+/** Scale a bbox between resolutions (round outward: floor origins, ceil extents; clamp). */
+export function scaleBox(box: Box, fromW: number, fromH: number, toW: number, toH: number): Box {
+  const sx = toW / fromW;
+  const sy = toH / fromH;
+  const x0 = clamp(Math.floor(box.x * sx), 0, toW);
+  const y0 = clamp(Math.floor(box.y * sy), 0, toH);
+  const x1 = clamp(Math.ceil((box.x + box.w) * sx), 0, toW);
+  const y1 = clamp(Math.ceil((box.y + box.h) * sy), 0, toH);
+  return { x: x0, y: y0, w: x1 - x0, h: y1 - y0 };
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, v));
+}
+
+// ---------------------------------------------------------------------------
+// I/O wrappers
+// ---------------------------------------------------------------------------
+
+export async function getImageSize(imagePath: string, ctx: AppContext): Promise<{ width: number; height: number }> {
+  const { stdout } = await execa(ctx.config.IM_CONVERT_BIN, [imagePath, "-format", "%w %h", "info:"], { shell: false });
+  const [w, h] = stdout.trim().split(/\s+/).map((s) => parseInt(s, 10));
+  return { width: w, height: h };
+}
+
+export async function computeRowMeans(imagePath: string, ctx: AppContext): Promise<number[]> {
+  const { stdout } = await execa(
+    ctx.config.IM_CONVERT_BIN,
+    [imagePath, "-colorspace", "Gray", "-resize", `1x${PROFILE_SAMPLES}!`, "-depth", "8", "txt:-"],
+    { shell: false }
+  );
+  return parseGrayProfile(stdout);
+}
+
+export type CarrierDetection = {
+  detected: boolean;
+  band_rows?: [number, number];
+  width: number;
+  height: number;
+};
+
+export async function detectCarrierSheet(imagePath: string, ctx: AppContext): Promise<CarrierDetection> {
+  const { width, height } = await getImageSize(imagePath, ctx);
+  const means = await computeRowMeans(imagePath, ctx);
+  const band = detectBandFromRowMeans(means);
+  if (!band) return { detected: false, width, height };
+  const band_rows = bandSamplesToRows(band, PROFILE_SAMPLES, height);
+  return { detected: true, band_rows, width, height };
+}
+
+export type CropResult = { crop_box: { x: number; y: number; width: number; height: number } };
+
+export async function cropCarrierSheet(
+  imagePath: string,
+  outPath: string,
+  bandRows: [number, number],
+  dims: { width: number; height: number },
+  ctx: AppContext
+): Promise<CropResult> {
+  const { width, height } = dims;
+  const chopY = bandRows[1] + Math.round(0.01 * height);
+  const fallbackBox: Box = { x: 0, y: chopY, w: width, h: Math.max(0, height - chopY) };
+
+  const box = await computeDocumentBox(imagePath, chopY, width, height, ctx).catch(() => null);
+  const cropBox = box ?? fallbackBox;
+
+  await execa(
+    ctx.config.IM_CONVERT_BIN,
+    [imagePath, "-crop", `${cropBox.w}x${cropBox.h}+${cropBox.x}+${cropBox.y}`, "+repage", outPath],
+    { shell: false }
+  );
+
+  return { crop_box: { x: cropBox.x, y: cropBox.y, width: cropBox.w, height: cropBox.h } };
+}
+
+async function computeDocumentBox(
+  imagePath: string,
+  chopY: number,
+  width: number,
+  height: number,
+  ctx: AppContext
+): Promise<Box | null> {
+  const srcW = width;
+  const srcH = height - chopY;
+  if (srcW <= 0 || srcH <= 0) return null;
+
+  const scale = Math.min(400 / srcW, 400 / srcH, 1);
+  const analysisW = Math.max(1, Math.round(srcW * scale));
+  const analysisH = Math.max(1, Math.round(srcH * scale));
+
+  const { stdout } = await execa(
+    ctx.config.IM_CONVERT_BIN,
+    [
+      imagePath,
+      "-crop",
+      `${srcW}x${srcH}+0+${chopY}`,
+      "+repage",
+      "-colorspace",
+      "Gray",
+      "-resize",
+      "400x400",
+      "-auto-threshold",
+      "Otsu",
+      "-define",
+      "connected-components:verbose=true",
+      "-define",
+      "connected-components:area-threshold=100",
+      "-connected-components",
+      "8",
+      "null:",
+    ],
+    { shell: false }
+  );
+
+  const components = parseConnectedComponents(stdout);
+  const picked = pickDocumentComponent(components, analysisW, analysisH);
+  if (!picked) return null;
+
+  const scaled = scaleBox(picked, analysisW, analysisH, srcW, srcH);
+  const offset: Box = { x: scaled.x, y: scaled.y + chopY, w: scaled.w, h: scaled.h };
+  // 2.5% margin: thresholding classifies dark document borders (e.g. certificate
+  // ornaments) as background, so the raw bbox can sit inside the paper edge.
+  return expandAndClampBox(offset, width, height, 0.025, chopY);
+}

--- a/src/services/carrier.ts
+++ b/src/services/carrier.ts
@@ -17,7 +17,7 @@ export type ConnectedComponent = { x: number; y: number; w: number; h: number; a
  * N luminance means normalized to 0..1, ordered by row.
  */
 export function parseGrayProfile(txt: string): number[] {
-  const rows: { y: number; value: number }[] = [];
+  const rows: number[] = [];
   const lineRe = /^\s*(\d+),(\d+):\s*\([^)]*\)\s*#[0-9A-Fa-f]+\s*(.+?)\s*$/;
   for (const line of txt.split(/\r?\n/)) {
     if (!line || line.startsWith("#")) continue;
@@ -26,14 +26,19 @@ export function parseGrayProfile(txt: string): number[] {
     const y = parseInt(m[2], 10);
     const value = colorSpecToUnit(m[3]);
     if (value === null) continue;
-    rows.push({ y, value });
+    // Place by row index rather than push+sort, so an unparseable/out-of-order
+    // line can't desynchronize the sample index from its row position.
+    rows[y] = value;
   }
-  rows.sort((a, b) => a.y - b.y);
-  return rows.map((r) => r.value);
+  return rows;
 }
 
-/** Parse a trailing color spec (`gray(NNN)`, `gray(NN%)`, `srgb(r,g,b)`) into a 0..1 unit value. */
+/** Parse a trailing color spec (`gray(NNN)`, `gray(NN%)`, `srgb(r,g,b)`, `black`, `white`) into a 0..1 unit value. */
 function colorSpecToUnit(spec: string): number | null {
+  const trimmed = spec.trim().toLowerCase();
+  if (trimmed === "black") return 0;
+  if (trimmed === "white") return 1;
+
   let m = /gray\((\d+(?:\.\d+)?)%\)/i.exec(spec);
   if (m) return parseFloat(m[1]) / 100;
 
@@ -82,6 +87,7 @@ export function detectBandFromRowMeans(
 
   let end = start;
   while (end + 1 < n && means[end + 1] < darkThreshold) end++;
+  const initialEnd = end;
 
   // Merge subsequent dark runs separated by short light gaps: patterns like the
   // Fujitsu filmstrip have a row of white sprocket squares inside the band, which
@@ -94,9 +100,16 @@ export function detectBandFromRowMeans(
     while (end + 1 < n && means[end + 1] < darkThreshold) end++;
   }
 
-  const length = end - start + 1;
   const maxStart = maxStartFrac * n;
   const maxThickness = maxThicknessFrac * n;
+  let length = end - start + 1;
+  if (length > maxThickness) {
+    // The merge overshot into a separate, too-thick dark region (e.g. a document
+    // with a dark top that immediately follows the band); fall back to the
+    // initial run rather than rejecting a genuine band.
+    end = initialEnd;
+    length = end - start + 1;
+  }
   if (start <= maxStart && length >= minThicknessSamples && length <= maxThickness) {
     return { start, end };
   }
@@ -185,6 +198,9 @@ function clamp(v: number, lo: number, hi: number): number {
 export async function getImageSize(imagePath: string, ctx: AppContext): Promise<{ width: number; height: number }> {
   const { stdout } = await execa(ctx.config.IM_CONVERT_BIN, [imagePath, "-format", "%w %h", "info:"], { shell: false });
   const [w, h] = stdout.trim().split(/\s+/).map((s) => parseInt(s, 10));
+  if (!Number.isFinite(w) || !Number.isFinite(h) || w <= 0 || h <= 0) {
+    throw new Error(`unparseable image size from ImageMagick: ${JSON.stringify(stdout)}`);
+  }
   return { width: w, height: h };
 }
 
@@ -194,7 +210,11 @@ export async function computeRowMeans(imagePath: string, ctx: AppContext): Promi
     [imagePath, "-colorspace", "Gray", "-resize", `1x${PROFILE_SAMPLES}!`, "-depth", "8", "txt:-"],
     { shell: false }
   );
-  return parseGrayProfile(stdout);
+  const profile = parseGrayProfile(stdout);
+  if (profile.length !== PROFILE_SAMPLES || profile.some((v) => v === undefined || !Number.isFinite(v))) {
+    throw new Error("unparseable gray profile from ImageMagick");
+  }
+  return profile;
 }
 
 export type CarrierDetection = {
@@ -263,7 +283,7 @@ async function computeDocumentBox(
       "-colorspace",
       "Gray",
       "-resize",
-      "400x400",
+      "400x400>",
       "-auto-threshold",
       "Otsu",
       "-define",

--- a/src/services/jobs.ts
+++ b/src/services/jobs.ts
@@ -174,7 +174,9 @@ async function runScan(runDir: string, manifest: Manifest, eventsPath: string, c
 async function processPages(runDir: string, manifest: Manifest, ctx: AppContext, eventsPath: string) {
   const { config } = ctx;
   const entries = await fs.readdir(runDir);
-  const pageFiles = entries.filter((f) => f.startsWith("page_") && f.endsWith(".tiff")).sort();
+  const pageFiles = entries
+    .filter((f) => f.startsWith("page_") && f.endsWith(".tiff") && !f.endsWith(".cropped.tiff"))
+    .sort();
   for (let idx = 0; idx < pageFiles.length; idx++) {
     const f = pageFiles[idx];
     const p = path.join(runDir, f);
@@ -232,14 +234,17 @@ async function detectAndCropCarrierSheets(manifest: Manifest, ctx: AppContext, e
         });
       }
     } catch (err) {
-      // Carrier detection/crop failures must never fail a scan job: log once and stop
-      // attempting detection for the remaining pages, but continue the job normally.
+      // Carrier detection/crop failures must never fail a scan job. Most errors
+      // (e.g. a malformed/unreadable single page) only affect that page, so log
+      // and move on. Only stop attempting detection for the remaining pages when
+      // the ImageMagick binary itself failed to spawn (ENOENT), since retrying
+      // per page is pointless if the tool is missing.
       await appendEvent(eventsPath, {
         ts: new Date().toISOString(),
         type: "carrier_detection_skipped",
-        data: { reason: String(err) },
+        data: { page: page.index, reason: String(err) },
       });
-      break;
+      if (isNodeError(err) && err.code === "ENOENT") break;
     }
   }
 }

--- a/src/services/jobs.ts
+++ b/src/services/jobs.ts
@@ -8,6 +8,7 @@ import type { AppConfig } from "../config.js";
 import { DEFAULT_RESOLUTION_DPI, LETTER_WIDTH_MM, LETTER_HEIGHT_MM, A4_WIDTH_MM, A4_HEIGHT_MM, LEGAL_WIDTH_MM, LEGAL_HEIGHT_MM } from "../constants.js";
 import { selectDevice } from "./select.js";
 import { getDeviceOptions } from "./sane.js";
+import { detectCarrierSheet, cropCarrierSheet } from "./carrier.js";
 
 import { tailTextFile, resolveJobPath } from "./utils.js";
 
@@ -34,6 +35,8 @@ export type StartScanInput = {
   };
   output_format?: string;
   tmp_dir?: string;
+  // Detect carrier sheet leading-edge band and crop derivatives.
+  crop_carrier_sheets?: boolean;
 };
 
 export type StartScanResult = {
@@ -47,7 +50,14 @@ type Manifest = {
   device_id: string | null;
   created_at: string;
   params: StartScanInput;
-  pages: { index: number; path: string; sha256: string }[];
+  pages: {
+    index: number;
+    path: string;
+    sha256: string;
+    carrier_sheet?: { detected: true; band_rows: [number, number] };
+    cropped_path?: string;
+    cropped_sha256?: string;
+  }[];
   documents: { index: number; pages: number[]; path: string; sha256: string }[];
   state: "running" | "completed" | "cancelled" | "error";
 };
@@ -161,7 +171,7 @@ async function runScan(runDir: string, manifest: Manifest, eventsPath: string, c
   return ran; // Return ran
 }
 
-async function processPages(runDir: string, manifest: Manifest, ctx: AppContext) {
+async function processPages(runDir: string, manifest: Manifest, ctx: AppContext, eventsPath: string) {
   const { config } = ctx;
   const entries = await fs.readdir(runDir);
   const pageFiles = entries.filter((f) => f.startsWith("page_") && f.endsWith(".tiff")).sort();
@@ -171,14 +181,66 @@ async function processPages(runDir: string, manifest: Manifest, ctx: AppContext)
     manifest.pages.push({ index: idx + 1, path: p, sha256: await hashFile(p) });
   }
 
+  await detectAndCropCarrierSheets(manifest, ctx, eventsPath);
+
   const segments = segmentPages(manifest.pages.map((p) => p.index), manifest.params.doc_break_policy);
   let docIdx = 1;
   for (const seg of segments) {
     const outDoc = path.join(runDir, `doc_${String(docIdx).padStart(4, "0")}.tiff`);
-    const segFiles = seg.map((i) => manifest.pages[i - 1]?.path).filter(Boolean) as string[];
+    const segFiles = seg
+      .map((i) => manifest.pages[i - 1])
+      .filter(Boolean)
+      .map((pg) => pg!.cropped_path ?? pg!.path);
     await assembleTiff(segFiles, outDoc, config);
     manifest.documents.push({ index: docIdx, pages: seg, path: outDoc, sha256: await hashFile(outDoc) });
     docIdx++;
+  }
+}
+
+async function detectAndCropCarrierSheets(manifest: Manifest, ctx: AppContext, eventsPath: string) {
+  const { config } = ctx;
+  if (config.SCAN_MOCK) return;
+
+  const cropRequested = Boolean(manifest.params.crop_carrier_sheets);
+  for (const page of manifest.pages) {
+    try {
+      const result = await detectCarrierSheet(page.path, ctx);
+      if (!result.detected || !result.band_rows) continue;
+
+      page.carrier_sheet = { detected: true, band_rows: result.band_rows };
+      await appendEvent(eventsPath, {
+        ts: new Date().toISOString(),
+        type: "carrier_sheet_detected",
+        data: { page: page.index, band_rows: result.band_rows },
+      });
+
+      if (cropRequested) {
+        const croppedPath = page.path.replace(/\.tiff$/, ".cropped.tiff");
+        const { crop_box } = await cropCarrierSheet(
+          page.path,
+          croppedPath,
+          result.band_rows,
+          { width: result.width, height: result.height },
+          ctx
+        );
+        page.cropped_path = croppedPath;
+        page.cropped_sha256 = await hashFile(croppedPath);
+        await appendEvent(eventsPath, {
+          ts: new Date().toISOString(),
+          type: "carrier_sheet_cropped",
+          data: { page: page.index, crop_box },
+        });
+      }
+    } catch (err) {
+      // Carrier detection/crop failures must never fail a scan job: log once and stop
+      // attempting detection for the remaining pages, but continue the job normally.
+      await appendEvent(eventsPath, {
+        ts: new Date().toISOString(),
+        type: "carrier_detection_skipped",
+        data: { reason: String(err) },
+      });
+      break;
+    }
   }
 }
 
@@ -212,7 +274,7 @@ export async function startScanJob(input: StartScanInput, ctx: AppContext): Prom
     return { job_id: manifest.job_id, run_dir: runDir, state: manifest.state };
   }
 
-  await processPages(runDir, manifest, ctx);
+  await processPages(runDir, manifest, ctx, eventsPath);
 
   manifest.state = "completed";
   await updateManifest(runDir, manifest);

--- a/src/tests/carrier.spec.ts
+++ b/src/tests/carrier.spec.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseGrayProfile,
+  detectBandFromRowMeans,
+  bandSamplesToRows,
+  parseConnectedComponents,
+  pickDocumentComponent,
+  expandAndClampBox,
+  scaleBox,
+  PROFILE_SAMPLES,
+} from "../services/carrier.js";
+
+describe("parseGrayProfile", () => {
+  it("parses gray(NNN) form", () => {
+    const txt = ["# ImageMagick pixel enumeration: 1,3,255,srgb", "0,0: (12593)  #313131  gray(49)", "0,1: (0)  #000000  gray(0)", "0,2: (65535)  #FFFFFF  gray(255)"].join("\n");
+    expect(parseGrayProfile(txt)).toEqual([49 / 255, 0, 1]);
+  });
+
+  it("parses gray(NN%) form", () => {
+    const txt = ["0,0: (0)  #000000  gray(0%)", "0,1: (0)  #7F7F7F  gray(50%)", "0,2: (0)  #FFFFFF  gray(100%)"].join("\n");
+    expect(parseGrayProfile(txt)).toEqual([0, 0.5, 1]);
+  });
+
+  it("parses srgb(r,g,b) form (averaged)", () => {
+    const txt = ["0,0: (0)  #000000  srgb(0,0,0)", "0,1: (0)  #7F7F7F  srgb(100,127,150)"].join("\n");
+    const parsed = parseGrayProfile(txt);
+    expect(parsed[0]).toBeCloseTo(0);
+    expect(parsed[1]).toBeCloseTo((100 + 127 + 150) / 3 / 255);
+  });
+
+  it("orders by row and ignores the header line", () => {
+    const txt = ["# ImageMagick pixel enumeration: 1,3,255,srgb", "0,2: (0)  #000000  gray(30)", "0,0: (0)  #000000  gray(10)", "0,1: (0)  #000000  gray(20)"].join("\n");
+    expect(parseGrayProfile(txt)).toEqual([10 / 255, 20 / 255, 30 / 255]);
+  });
+});
+
+function buildProfile(n: number, darkRanges: Array<[number, number, number]>, baseline = 0.9): number[] {
+  const means = new Array(n).fill(baseline);
+  for (const [start, end, value] of darkRanges) {
+    for (let i = start; i <= end; i++) means[i] = value;
+  }
+  return means;
+}
+
+describe("detectBandFromRowMeans", () => {
+  it("detects a fujitsu-like leading-edge band", () => {
+    const means = buildProfile(PROFILE_SAMPLES, [[0, 8, 0.35]]);
+    expect(detectBandFromRowMeans(means)).toEqual({ start: 0, end: 8 });
+  });
+
+  it("detects a brother-like solid black bar", () => {
+    const means = buildProfile(PROFILE_SAMPLES, [[0, 10, 0.03]]);
+    expect(detectBandFromRowMeans(means)).toEqual({ start: 0, end: 10 });
+  });
+
+  it("returns null for a clean page", () => {
+    const means = buildProfile(PROFILE_SAMPLES, []);
+    expect(detectBandFromRowMeans(means)).toBeNull();
+  });
+
+  it("returns null for a dark-topped photo (exceeds max thickness)", () => {
+    const means = buildProfile(PROFILE_SAMPLES, [[0, 120, 0.1]]);
+    expect(detectBandFromRowMeans(means)).toBeNull();
+  });
+
+  it("returns null when the dark run starts too far down the page", () => {
+    const means = buildProfile(PROFILE_SAMPLES, [[40, 50, 0.1]]);
+    expect(detectBandFromRowMeans(means)).toBeNull();
+  });
+
+  it("returns null for a single-sample noise spike", () => {
+    const means = buildProfile(PROFILE_SAMPLES, [[0, 0, 0.1]]);
+    expect(detectBandFromRowMeans(means)).toBeNull();
+  });
+
+  it("merges dark runs split by a sprocket-square row (fujitsu filmstrip)", () => {
+    const means = buildProfile(PROFILE_SAMPLES, [
+      [8, 11, 0.2],
+      [12, 14, 0.65],
+      [15, 20, 0.2],
+    ]);
+    expect(detectBandFromRowMeans(means)).toEqual({ start: 8, end: 20 });
+  });
+
+  it("does not merge across a gap wider than maxGapSamples", () => {
+    const means = buildProfile(PROFILE_SAMPLES, [
+      [0, 4, 0.2],
+      [12, 16, 0.2],
+    ]);
+    expect(detectBandFromRowMeans(means)).toEqual({ start: 0, end: 4 });
+  });
+});
+
+describe("bandSamplesToRows", () => {
+  it("maps sample indices to pixel rows", () => {
+    expect(bandSamplesToRows({ start: 0, end: 8 }, 256, 3300)).toEqual([0, 117]);
+  });
+
+  it("clamps end row to imageHeight - 1", () => {
+    expect(bandSamplesToRows({ start: 254, end: 255 }, 256, 256)).toEqual([254, 255]);
+  });
+});
+
+describe("scaleBox", () => {
+  it("scales a box between resolutions, rounding outward", () => {
+    const box = { x: 10, y: 10, w: 100, h: 200 };
+    const scaled = scaleBox(box, 400, 400, 4000, 4000);
+    expect(scaled).toEqual({ x: 100, y: 100, w: 1000, h: 2000 });
+  });
+
+  it("clamps to the target bounds", () => {
+    const box = { x: 0, y: 0, w: 400, h: 400 };
+    const scaled = scaleBox(box, 400, 400, 4000, 3000);
+    expect(scaled).toEqual({ x: 0, y: 0, w: 4000, h: 3000 });
+  });
+});
+
+describe("expandAndClampBox", () => {
+  it("expands by marginFrac of the larger dimension", () => {
+    const box = { x: 100, y: 100, w: 200, h: 200 };
+    // imgW=1000, imgH=2000 -> margin = 0.01 * 2000 = 20
+    const out = expandAndClampBox(box, 1000, 2000, 0.01, 0);
+    expect(out).toEqual({ x: 80, y: 80, w: 240, h: 240 });
+  });
+
+  it("clamps x to [0, imgW] and y to [minY, imgH]", () => {
+    const box = { x: 5, y: 5, w: 990, h: 100 };
+    const out = expandAndClampBox(box, 1000, 200, 0.05, 50);
+    expect(out.x).toBeGreaterThanOrEqual(0);
+    expect(out.x + out.w).toBeLessThanOrEqual(1000);
+    expect(out.y).toBeGreaterThanOrEqual(50);
+    expect(out.y + out.h).toBeLessThanOrEqual(200);
+  });
+});
+
+describe("parseConnectedComponents", () => {
+  const verbose = [
+    "Objects (id: bounding-box centroid area mean-color):",
+    "  0: 400x400+0+0 199.5,199.5 160000 gray(0)",
+    "  1: 40x40+0+0 19.5,19.5 1200 gray(10)",
+    "  2: 313x412+44+0 200.0,270.9 128561 gray(255)",
+  ].join("\n");
+
+  it("parses components and skips the header", () => {
+    const components = parseConnectedComponents(verbose);
+    expect(components).toHaveLength(3);
+    expect(components[2]).toEqual({ x: 44, y: 0, w: 313, h: 412, area: 128561, color: "gray(255)" });
+  });
+});
+
+describe("pickDocumentComponent", () => {
+  it("picks the largest light component", () => {
+    const components = [
+      { x: 0, y: 0, w: 400, h: 400, area: 160000, color: "gray(0)" },
+      { x: 0, y: 0, w: 40, h: 40, area: 1200, color: "gray(255)" },
+      { x: 44, y: 0, w: 313, h: 412, area: 128561, color: "gray(255)" },
+    ];
+    expect(pickDocumentComponent(components, 400, 400)).toEqual({ x: 44, y: 0, w: 313, h: 412 });
+  });
+
+  it("returns null when no light component qualifies (dark only)", () => {
+    const components = [{ x: 0, y: 0, w: 400, h: 400, area: 160000, color: "gray(0)" }];
+    expect(pickDocumentComponent(components, 400, 400)).toBeNull();
+  });
+
+  it("returns null when the largest light component is too small", () => {
+    const components = [{ x: 0, y: 0, w: 20, h: 20, area: 400, color: "gray(255)" }];
+    // 400 / (400*400) = 0.25% < 2%
+    expect(pickDocumentComponent(components, 400, 400)).toBeNull();
+  });
+});

--- a/src/tests/carrier.spec.ts
+++ b/src/tests/carrier.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   parseGrayProfile,
   detectBandFromRowMeans,
@@ -7,8 +7,12 @@ import {
   pickDocumentComponent,
   expandAndClampBox,
   scaleBox,
+  detectCarrierSheet,
   PROFILE_SAMPLES,
 } from "../services/carrier.js";
+import type { AppConfig } from "../config.js";
+import type { AppContext } from "../context.js";
+import type { Logger } from "pino";
 
 describe("parseGrayProfile", () => {
   it("parses gray(NNN) form", () => {
@@ -31,6 +35,23 @@ describe("parseGrayProfile", () => {
   it("orders by row and ignores the header line", () => {
     const txt = ["# ImageMagick pixel enumeration: 1,3,255,srgb", "0,2: (0)  #000000  gray(30)", "0,0: (0)  #000000  gray(10)", "0,1: (0)  #000000  gray(20)"].join("\n");
     expect(parseGrayProfile(txt)).toEqual([10 / 255, 20 / 255, 30 / 255]);
+  });
+
+  it("parses named colors black and white", () => {
+    const txt = ["0,0: (0)  #000000  black", "0,1: (0)  #FFFFFF  white"].join("\n");
+    expect(parseGrayProfile(txt)).toEqual([0, 1]);
+  });
+
+  it("places values by y index even with an unparseable line in between (gappy fixture)", () => {
+    const txt = [
+      "0,0: (0)  #000000  gray(10)",
+      "0,1: this line is garbage and does not match",
+      "0,2: (0)  #000000  gray(30)",
+    ].join("\n");
+    const parsed = parseGrayProfile(txt);
+    expect(parsed[0]).toBeCloseTo(10 / 255);
+    expect(parsed[1]).toBeUndefined();
+    expect(parsed[2]).toBeCloseTo(30 / 255);
   });
 });
 
@@ -88,6 +109,17 @@ describe("detectBandFromRowMeans", () => {
       [12, 16, 0.2],
     ]);
     expect(detectBandFromRowMeans(means)).toEqual({ start: 0, end: 4 });
+  });
+
+  it("falls back to the initial run when merging would overshoot into a too-thick dark region", () => {
+    // Band [0,8], short gap [9,11], then a dark document top [12,60] that would
+    // merge into a too-thick run if not for the fallback.
+    const means = buildProfile(PROFILE_SAMPLES, [
+      [0, 8, 0.2],
+      [9, 11, 0.9],
+      [12, 60, 0.2],
+    ]);
+    expect(detectBandFromRowMeans(means)).toEqual({ start: 0, end: 8 });
   });
 });
 
@@ -167,5 +199,25 @@ describe("pickDocumentComponent", () => {
     const components = [{ x: 0, y: 0, w: 20, h: 20, area: 400, color: "gray(255)" }];
     // 400 / (400*400) = 0.25% < 2%
     expect(pickDocumentComponent(components, 400, 400)).toBeNull();
+  });
+});
+
+describe("detectCarrierSheet error containment", () => {
+  it("rejects when IM_CONVERT_BIN points to a nonexistent binary", async () => {
+    const config: AppConfig = {
+      SCAN_MOCK: false,
+      INBOX_DIR: "/tmp",
+      LOG_LEVEL: "silent",
+      SCAN_EXCLUDE_BACKENDS: [],
+      SCAN_PREFER_BACKENDS: [],
+      SCANIMAGE_BIN: "scanimage",
+      TIFFCP_BIN: "tiffcp",
+      IM_CONVERT_BIN: "/nonexistent-convert-bin",
+      PERSIST_LAST_USED_DEVICE: false,
+    };
+    const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } as unknown as Logger;
+    const ctx: AppContext = { config, logger };
+
+    await expect(detectCarrierSheet("/tmp/does-not-matter.tiff", ctx)).rejects.toThrow();
   });
 });

--- a/src/tests/jobs_mock.spec.ts
+++ b/src/tests/jobs_mock.spec.ts
@@ -52,4 +52,17 @@ describe("startScanJob (mock)", () => {
     const cancel = await cancelJob(res.job_id, ctx, tmpRoot);
     expect(cancel.ok).toBe(true);
   });
+
+  it("skips carrier sheet detection entirely (manifest pages have no carrier fields)", async () => {
+    const res = await startScanJob({ tmp_dir: tmpRoot, crop_carrier_sheets: true }, ctx);
+    const manifestPath = path.join(res.run_dir, "manifest.json");
+    const manifest = JSON.parse(await fs.readFile(manifestPath, "utf8"));
+    expect(manifest.state).toBe("completed");
+    expect(manifest.pages.length).toBeGreaterThan(0);
+    for (const page of manifest.pages) {
+      expect(page.carrier_sheet).toBeUndefined();
+      expect(page.cropped_path).toBeUndefined();
+      expect(page.cropped_sha256).toBeUndefined();
+    }
+  });
 });

--- a/src/tests/register.test.ts
+++ b/src/tests/register.test.ts
@@ -1,10 +1,14 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterAll } from "vitest";
+import { promises as fs } from "fs";
+import path from "path";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerScanServer } from "../server/register.js";
 import type { AppConfig } from "../config.js";
 import type { AppContext } from "../context.js";
 import type { Logger } from "pino";
 import { version } from "../mcp.js";
+
+const tmpCropDir = path.resolve(__dirname, ".tmp-register-crop-carrier");
 
 const baseConfig: AppConfig = {
   SCAN_MOCK: true,
@@ -20,6 +24,12 @@ const baseConfig: AppConfig = {
 
 const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } as unknown as Logger;
 const ctx: AppContext = { config: baseConfig, logger };
+
+afterAll(async () => {
+  try {
+    await fs.rm(tmpCropDir, { recursive: true, force: true });
+  } catch {}
+});
 
 describe("registerScanServer", () => {
   it("registers expected tools and resources", () => {
@@ -64,6 +74,25 @@ describe("registerScanServer", () => {
     const result = await tool.callback({ job_id: "job-00000000-0000-0000-0000-000000000000" });
     expect(result.isError).toBe(true);
     expect(result.content[0].type).toBe("text");
+  });
+
+  it("start_scan_job accepts crop_carrier_sheets: true and null", async () => {
+    // Use a dedicated INBOX_DIR (rather than tmp_dir on the input) so the
+    // last-used-device state file lands under the test's own tmp dir instead
+    // of the fixed baseConfig.INBOX_DIR (which may not be writable here).
+    const cropCtx: AppContext = { config: { ...baseConfig, INBOX_DIR: tmpCropDir, PERSIST_LAST_USED_DEVICE: false }, logger };
+    const server = new McpServer({ name: "scan-mcp", version }, { capabilities: { tools: {}, resources: {} } });
+    registerScanServer(server, cropCtx);
+    const internal = server as unknown as {
+      _registeredTools: Record<string, { callback: (args: unknown) => Promise<{ content: { type: string; text: string }[] }> }>;
+    };
+    const tool = internal._registeredTools["start_scan_job"];
+
+    const withTrue = await tool.callback({ crop_carrier_sheets: true });
+    expect(JSON.parse(withTrue.content[0].text).state).toBe("completed");
+
+    const withNull = await tool.callback({ crop_carrier_sheets: null });
+    expect(JSON.parse(withNull.content[0].text).state).toBe("completed");
   });
 
   it("get_manifest rejects malicious job_id", async () => {

--- a/src/tests/schema.spec.ts
+++ b/src/tests/schema.spec.ts
@@ -75,6 +75,7 @@ describe("JSON Schemas", () => {
       doc_break_policy: { type: "page_count", page_count: 1 },
       output_format: "pdf",
       tmp_dir: "/tmp/scans",
+      crop_carrier_sheets: true,
     };
     expect(validate(validData)).toBe(true);
     expect(validate.errors).toBeNull();


### PR DESCRIPTION
## Summary
- Always-on detection: pages scanned inside a carrier sheet (Fujitsu/Brother/Epson clear sleeves) are recognized by the dark leading-edge pattern band, via a 256-sample row-luminance profile; affected manifest pages gain `carrier_sheet: { detected: true, band_rows }`.
- The Fujitsu filmstrip's white sprocket row splits the band into two dark runs in the profile; detection merges dark runs across short light gaps so the full band extent is measured.
- Opt-in crop: `crop_carrier_sheets: true` on `start_scan_job` writes a `page_XXXX.cropped.tiff` derivative per affected page (`cropped_path`/`cropped_sha256` in the manifest) and assembles documents from the derivatives. The document bounding box comes from Otsu thresholding + connected components on a downscaled copy, with a 2.5% margin so dark document borders survive; on any analysis failure it falls back to just removing the band. Raw pages are never modified or deleted.
- Carrier detection/crop failures never fail a scan job (logged as `carrier_detection_skipped` events).
- Uses the existing `IM_CONVERT_BIN` ImageMagick dependency; no new packages.

## Validation
- 86 unit tests pass (`npm run verify`: lint + typecheck + vitest), including pure-function coverage of profile parsing, band detection (incl. sprocket-gap merging, dark-photo rejection), bbox math, and connected-component parsing.
- End-to-end validated against real ScanSnap S1500 carrier sheet scans (a folded certificate, its blank back side, and a small receipt): band removed on all three; the receipt is cropped precisely to the paper; the certificate keeps its full decorative border.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgFozZrLmjwMBWr69J26bb